### PR TITLE
Fix video thumbnail gen

### DIFF
--- a/engine/_classes/class.bertagallery.php
+++ b/engine/_classes/class.bertagallery.php
@@ -388,7 +388,7 @@ class BertaGallery extends BertaBase
 
         $imgs = BertaGallery::getImagesArray($section);
         $mediaFolder = $section['mediafolder'];
-        $mFolder = self::$options['MEDIA_URL'] . $mediaFolder . '/';
+        $mFolder = self::$options['MEDIA_ROOT'] . $mediaFolder . '/';
         $mFolderABS = self::$options['MEDIA_ABS_ROOT'] . $mediaFolder . '/';
 
         $alwaysSelectTag = $berta->settings->get('navigation', 'alwaysSelectTag') == 'yes';

--- a/engine/_classes/class.bertagallery.php
+++ b/engine/_classes/class.bertagallery.php
@@ -124,7 +124,7 @@ class BertaGallery extends BertaBase
 
     public static function getImageHTML($img, $mediaFolder, $isAdminMode = false, $sizeRatio = 1, $imageTargetWidth = 0, $imageTargetHeight = 0)
     {
-        $mFolder = self::$options['MEDIA_URL'] . $mediaFolder . '/';
+        $mFolder = self::$options['MEDIA_ROOT'] . $mediaFolder . '/';
         $mFolderABS = self::$options['MEDIA_ABS_ROOT'] . $mediaFolder . '/';
         $realWidth = $width = $realHeight = $height = 0;
 


### PR DESCRIPTION
- Fixed video thumbnail generation - fixed file path
- Improved file limits
    * Now limiting images to their sizes in MB rather than PX (5MB for gif and 3MB for others).
    * Improved limit error messages