### PR TITLE
Reorder Berta sections with Drag & Drop

### DIFF
--- a/editor/src/app/preview/preview.service.ts
+++ b/editor/src/app/preview/preview.service.ts
@@ -13,11 +13,12 @@ import {
   RenameSiteSectionAction,
   DeleteSiteSectionAction,
   DeleteSiteSectionsAction,
-  UpdateSiteSectionBackgroundFromSyncAction
+  UpdateSiteSectionBackgroundFromSyncAction,
+  ReOrderSiteSectionsAction
 } from '../sites/sections/sections-state/site-sections.actions';
 import { UpdateSiteSettingsFromSyncAction, UpdateSiteSettingsAction } from '../sites/settings/site-settings.actions';
 import { UpdateSiteTemplateSettingsAction } from '../sites/template-settings/site-template-settings.actions';
-import { CreateSiteAction, DeleteSiteAction, UpdateSiteAction } from '../sites/sites-state/sites.actions';
+import { CreateSiteAction, DeleteSiteAction, UpdateSiteAction, ReOrderSitesAction } from '../sites/sites-state/sites.actions';
 import {
   UpdateSectionEntryFromSyncAction,
   OrderSectionEntriesFromSyncAction,
@@ -324,11 +325,13 @@ export class PreviewService {
         ...[
           CreateSiteAction,
           UpdateSiteAction,
+          ReOrderSitesAction,
           DeleteSiteAction,
           AddSiteSectionsAction,
           UpdateSiteSectionAction,
           RenameSiteSectionAction,
-          DeleteSiteSectionAction,  // *
+          ReOrderSiteSectionsAction,
+          DeleteSiteSectionAction,
           DeleteSiteSectionsAction,
           UpdateSiteSettingsAction,
           UpdateSiteTemplateSettingsAction

--- a/editor/src/app/sites/sections/section.component.ts
+++ b/editor/src/app/sites/sections/section.component.ts
@@ -14,8 +14,8 @@ import { DeleteSiteSectionAction, CloneSectionAction } from './sections-state/si
                                  (update)="updateTextField('title', $event)"></berta-inline-text-input>
 
         <div class="expand"></div>
-        <button [attr.title]="section['@attributes'].published > 0 ? 'Unpublish': 'Publish'"
-                (click)="updateField({'@attributes': {published: section['@attributes'].published > 0 ? '0' : '1'}})">
+        <button [attr.title]="(section['@attributes'].published > 0 ? 'Unpublish': 'Publish')"
+                (click)="updateField({'@attributes': {published: (section['@attributes'].published > 0 ? '0' : '1')}})">
           <berta-icon-publish [published]="(section['@attributes'].published > 0)"></berta-icon-publish>
         </button>
         <button title="copy"

--- a/editor/src/app/sites/sections/sections-state/site-sections.actions.ts
+++ b/editor/src/app/sites/sections/sections-state/site-sections.actions.ts
@@ -64,6 +64,14 @@ export class DeleteSiteSectionAction {
   }
 }
 
+export class ReOrderSiteSectionsAction {
+  static readonly type = 'SITE_SECTIONS:REORDER';
+  constructor(
+    public currentOrder: number,
+    public payload: number) {
+  }
+}
+
 export class DeleteSiteSectionsAction {
   static readonly type = 'SITE_SECTIONS:DELETE';
   constructor(public siteName: string) {

--- a/editor/src/app/sites/sections/sections-state/site-sections.state.ts
+++ b/editor/src/app/sites/sections/sections-state/site-sections.state.ts
@@ -252,7 +252,7 @@ export class SiteSectionsState implements NgxsOnInit {
   @Action(ReOrderSiteSectionsAction)
   ReOrderSiteSections({ getState, setState }: StateContext<SiteSectionStateModel[]>, action: ReOrderSiteSectionsAction) {
     const siteName = this.store.selectSnapshot(AppState.getSite);
-    const sectionsToSort = getState().filter(section => section.site_name === siteName);
+    const sectionsToSort = this.store.selectSnapshot(SiteSectionsState.getCurrentSiteSections);
 
     sectionsToSort.sort((sectionA, sectionB) => {
       if (sectionA.order !== action.currentOrder && sectionB.order !== action.currentOrder) {

--- a/editor/src/app/sites/sections/sections-state/site-sections.state.ts
+++ b/editor/src/app/sites/sections/sections-state/site-sections.state.ts
@@ -19,7 +19,8 @@ import {
   AddSiteSectionsAction,
   ResetSiteSectionsAction,
   InitSiteSectionsAction,
-  UpdateSiteSectionBackgroundFromSyncAction} from './site-sections.actions';
+  UpdateSiteSectionBackgroundFromSyncAction,
+  ReOrderSiteSectionsAction} from './site-sections.actions';
 import { DeleteSectionTagsAction, RenameSectionTagsAction, AddSectionTagsAction } from '../tags/section-tags.actions';
 import {
   DeleteSectionEntriesAction,
@@ -38,7 +39,7 @@ export class SiteSectionsState implements NgxsOnInit {
   static getCurrentSiteSections(state, site) {
     return state.filter(section => {
       return section.site_name === site;
-    });
+    }).sort((sectionA, sectionB) => sectionA.order > sectionB.order ? 1 : -1);
   }
 
   constructor(private appStateService: AppStateService,
@@ -244,6 +245,47 @@ export class SiteSectionsState implements NgxsOnInit {
           return section;
         }
         return {...section, ...{'site_name': action.siteName}};
+      })
+    );
+  }
+
+  @Action(ReOrderSiteSectionsAction)
+  ReOrderSiteSectionsAction({ getState, setState }: StateContext<SiteSectionStateModel[]>, action: ReOrderSiteSectionsAction) {
+    const siteName = this.store.selectSnapshot(AppState.getSite);
+    const sectionsToSort = getState().filter(section => section.site_name === siteName);
+
+    sectionsToSort.sort((sectionA, sectionB) => {
+      if (sectionA.order !== action.currentOrder && sectionB.order !== action.currentOrder) {
+        return sectionB.order > sectionA.order ? -1 : 1;
+      } else if (sectionA.order === action.currentOrder) {
+        return sectionB.order >= action.payload ? -1 : 1;
+      } else if (sectionB.order === action.currentOrder) {
+        return action.payload >= sectionA.order ? -1 : 1;
+      }
+    });
+
+    return this.appStateService.sync('siteSections', {
+      site: siteName,
+      sections: sectionsToSort.map(section => section.name)
+    }, 'PUT').pipe(
+      tap(response => {
+        if (response.error_message) {
+          // @TODO handle error message
+          console.error(response.error_message);
+        } else {
+          const sites = getState();
+
+          setState(sites.map(section => {
+            if ((<string[]> response.sections).indexOf(section.name) === -1) {
+              // The order of this section was not updated in this request
+              return section;
+            }
+            return {
+              ...section,
+              order: (<string[]> response.sections).indexOf(section.name)
+            };
+          }));
+        }
       })
     );
   }

--- a/editor/src/app/sites/sections/sections-state/site-sections.state.ts
+++ b/editor/src/app/sites/sections/sections-state/site-sections.state.ts
@@ -250,7 +250,7 @@ export class SiteSectionsState implements NgxsOnInit {
   }
 
   @Action(ReOrderSiteSectionsAction)
-  ReOrderSiteSectionsAction({ getState, setState }: StateContext<SiteSectionStateModel[]>, action: ReOrderSiteSectionsAction) {
+  ReOrderSiteSections({ getState, setState }: StateContext<SiteSectionStateModel[]>, action: ReOrderSiteSectionsAction) {
     const siteName = this.store.selectSnapshot(AppState.getSite);
     const sectionsToSort = getState().filter(section => section.site_name === siteName);
 

--- a/editor/src/app/sites/sections/sections-state/site-sections.state.ts
+++ b/editor/src/app/sites/sections/sections-state/site-sections.state.ts
@@ -250,7 +250,7 @@ export class SiteSectionsState implements NgxsOnInit {
   }
 
   @Action(ReOrderSiteSectionsAction)
-  ReOrderSiteSections({ getState, setState }: StateContext<SiteSectionStateModel[]>, action: ReOrderSiteSectionsAction) {
+  reOrderSiteSections({ getState, setState }: StateContext<SiteSectionStateModel[]>, action: ReOrderSiteSectionsAction) {
     const siteName = this.store.selectSnapshot(AppState.getSite);
     const sectionsToSort = this.store.selectSnapshot(SiteSectionsState.getCurrentSiteSections);
 

--- a/editor/src/app/sites/sections/site-sections.component.ts
+++ b/editor/src/app/sites/sections/site-sections.component.ts
@@ -20,22 +20,24 @@ import { SettingConfigModel, SettingModel } from '../../shared/interfaces';
 @Component({
   selector: 'berta-site-sections',
   template: `
-    <berta-section *ngFor="let sd of sectionsData$ | async"
-                   draggable="true"
-                   [class.bt-sort-place-after]="dragOverIndex === sd.section.order && draggedIndex < dragOverIndex"
-                   [class.bt-sort-place-before]="dragOverIndex === sd.section.order && draggedIndex > dragOverIndex"
-                   [class.bt-sort-is-dragged]="sd.section.order === draggedIndex && hideElement"
-                   (dragstart)="siteDragStart($event, sd.section)"
-                   (dragover)="dragOver($event, sd.section)"
-                   (drop)="onDrop($event)"
-                   (dragend)="resetDrag()"
-                   [section]="sd.section"
-                   [isExpanded]="sd.section.name === currentSection"
-                   [params]="sd.params"
-                   [templateSectionTypes]="sectionTypes$ | async"
-                   (inputFocus)="updateComponentFocus($event)"
-                   (update)="updateSection(sd, $event)"></berta-section>
-    <button type="button" class="button" (click)="createSection()">Create new section</button>
+    <div class="berta-site-sections" [class.bt-reordering]="draggedIndex !== null">
+      <berta-section *ngFor="let sd of sectionsData$ | async"
+                    draggable="true"
+                    [class.bt-sort-place-after]="dragOverIndex === sd.section.order && draggedIndex < dragOverIndex"
+                    [class.bt-sort-place-before]="dragOverIndex === sd.section.order && draggedIndex > dragOverIndex"
+                    [class.bt-sort-is-dragged]="sd.section.order === draggedIndex && hideElement"
+                    (dragstart)="siteDragStart($event, sd.section)"
+                    (dragover)="dragOver($event, sd.section)"
+                    (drop)="onDrop($event)"
+                    (dragend)="resetDrag()"
+                    [section]="sd.section"
+                    [isExpanded]="sd.section.name === currentSection"
+                    [params]="sd.params"
+                    [templateSectionTypes]="sectionTypes$ | async"
+                    (inputFocus)="updateComponentFocus($event)"
+                    (update)="updateSection(sd, $event)"></berta-section>
+      <button type="button" class="button" (click)="createSection()">Create new section</button>
+    </div>
   `
 })
 export class SiteSectionsComponent implements OnInit {
@@ -181,9 +183,6 @@ export class SiteSectionsComponent implements OnInit {
     this.draggedIndex = +section.order;
     event.dataTransfer.dropEffect = 'move';
     event.dataTransfer.setData('text/plain', String(section.order));
-    this.dragAnchor.nativeElement.style.position = 'fixed';
-    this.dragAnchor.nativeElement.style.width = '383px';
-
 
     // Hide the element that's being dragged from the site list
     // Use delay so we get the image as drag anchor

--- a/editor/src/app/sites/sections/site-sections.component.ts
+++ b/editor/src/app/sites/sections/site-sections.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Store } from '@ngxs/store';
 import { Observable, combineLatest } from 'rxjs';
@@ -10,13 +10,25 @@ import { SiteSectionsState } from './sections-state/site-sections.state';
 import { camel2Words } from '../../shared/helpers';
 import { SiteTemplateSettingsState } from '../template-settings/site-template-settings.state';
 import { UpdateInputFocus } from '../../app-state/app.actions';
-import { UpdateSiteSectionAction, CreateSectionAction, RenameSiteSectionAction } from './sections-state/site-sections.actions';
+import {
+  UpdateSiteSectionAction,
+  CreateSectionAction,
+  RenameSiteSectionAction,
+  ReOrderSiteSectionsAction } from './sections-state/site-sections.actions';
 import { SettingConfigModel, SettingModel } from '../../shared/interfaces';
 
 @Component({
   selector: 'berta-site-sections',
   template: `
     <berta-section *ngFor="let sd of sectionsData$ | async"
+                   draggable="true"
+                   [class.bt-sort-place-after]="dragOverIndex === sd.section.order && draggedIndex < dragOverIndex"
+                   [class.bt-sort-place-before]="dragOverIndex === sd.section.order && draggedIndex > dragOverIndex"
+                   [class.bt-sort-is-dragged]="sd.section.order === draggedIndex && hideElement"
+                   (dragstart)="siteDragStart($event, sd.section)"
+                   (dragover)="dragOver($event, sd.section)"
+                   (drop)="onDrop($event)"
+                   (dragend)="resetDrag()"
                    [section]="sd.section"
                    [isExpanded]="sd.section.name === currentSection"
                    [params]="sd.params"
@@ -33,6 +45,12 @@ export class SiteSectionsComponent implements OnInit {
   }[]}[]>;
   sectionTypes$: Observable<{value: string, title: string}[]>;
   currentSection: string;
+
+  dragOverIndex: number|null = null;
+  draggedIndex: number|null = null;
+  hideElement = false;
+
+  @ViewChild('dragAnchor') dragAnchor: ElementRef;
 
   constructor(private store: Store,
               private router: Router,
@@ -156,5 +174,42 @@ export class SiteSectionsComponent implements OnInit {
     } else {
       this.store.dispatch(new UpdateSiteSectionAction(sectionData.section.site_name, parseInt(updateEvent.section, 10), updateEvent.data));
     }
+  }
+
+  siteDragStart(event: DragEvent, section: SiteSectionStateModel) {
+    event.stopPropagation();
+    this.draggedIndex = +section.order;
+    event.dataTransfer.dropEffect = 'move';
+    event.dataTransfer.setData('text/plain', String(section.order));
+    this.dragAnchor.nativeElement.style.position = 'fixed';
+    this.dragAnchor.nativeElement.style.width = '383px';
+
+
+    // Hide the element that's being dragged from the site list
+    // Use delay so we get the image as drag anchor
+    setTimeout(() => {
+      this.hideElement = true;
+    }, 10);
+  }
+
+  dragOver(event: DragEvent, section: SiteSectionStateModel) {
+    // For drop to work this must be prevented
+    event.preventDefault();
+    this.dragOverIndex = +section.order;
+  }
+
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.draggedIndex === this.dragOverIndex) {
+      return;
+    }
+    this.store.dispatch(new ReOrderSiteSectionsAction(this.draggedIndex, this.dragOverIndex));
+  }
+
+  resetDrag() {
+    this.dragOverIndex = null;
+    this.draggedIndex = null;
+    this.hideElement = false;
   }
 }

--- a/editor/src/app/sites/sites-state/sites.actions.ts
+++ b/editor/src/app/sites/sites-state/sites.actions.ts
@@ -35,6 +35,14 @@ export class DeleteSiteAction {
   }
 }
 
+export class ReOrderSitesAction {
+  static readonly type = 'SITE:REORDER';
+  constructor(
+    public currentOrder: number,
+    public payload: number) {
+  }
+}
+
 export class ResetSitesAction {
   static readonly type = 'SITE:RESET';
 }

--- a/editor/src/app/sites/sites-state/sites.state.ts
+++ b/editor/src/app/sites/sites-state/sites.state.ts
@@ -185,7 +185,7 @@ export class SitesState implements NgxsOnInit {
   }
 
   @Action(ReOrderSitesAction)
-  reOrderSitesAction({ getState, setState }: StateContext<SiteStateModel[]>, action: ReOrderSitesAction) {
+  reOrderSites({ getState, setState }: StateContext<SiteStateModel[]>, action: ReOrderSitesAction) {
     const sitesToSort = [...getState()];
 
     sitesToSort.sort((siteA, siteB) => {

--- a/editor/src/app/sites/sites.component.ts
+++ b/editor/src/app/sites/sites.component.ts
@@ -10,8 +10,8 @@ import { CreateSiteAction, ReOrderSitesAction } from './sites-state/sites.action
   template: `
     <div class="nice" (dragend)="resetDrag()" (drop)="onDrop($event)">
       <berta-site *ngFor="let site of sites$ | async"
-                  [class.bt-sort-place-after]="dragOverIndex === site.order && draggedIndex < dragOverIndex"
-                  [class.bt-sort-place-before]="dragOverIndex === site.order && draggedIndex > dragOverIndex"
+                  [class.bt-sort-place-after]="dragOverIndex > 0 && dragOverIndex === site.order && draggedIndex < dragOverIndex"
+                  [class.bt-sort-place-before]="dragOverIndex > 0 && dragOverIndex === site.order && draggedIndex > dragOverIndex"
                   draggable="true"
                   (dragstart)="siteDragStart($event, site)"
                   (dragover)="dragOver($event, site)"
@@ -38,6 +38,11 @@ export class SitesComponent {
   }
 
   siteDragStart(event, site) {
+    if (site.order === 0) {
+      // The home page is always the first one, don' t allow to move it
+      event.preventDefault();
+      return false;
+    }
     this.draggedIndex = +site.order;
     event.dataTransfer.dropEffect = 'move';
   }
@@ -51,7 +56,7 @@ export class SitesComponent {
   onDrop(event) {
     event.preventDefault();
     event.stopPropagation();
-    if (this.draggedIndex === this.dragOverIndex) {
+    if (this.draggedIndex === this.dragOverIndex || this.dragOverIndex === 0) {
       return;
     }
     this.store.dispatch(new ReOrderSitesAction(this.draggedIndex, this.dragOverIndex));

--- a/editor/src/app/sites/sites.component.ts
+++ b/editor/src/app/sites/sites.component.ts
@@ -10,9 +10,10 @@ import { CreateSiteAction, ReOrderSitesAction } from './sites-state/sites.action
   template: `
     <div class="nice" (dragend)="resetDrag()" (drop)="onDrop($event)">
       <berta-site *ngFor="let site of sites$ | async"
+                  draggable="true"
                   [class.bt-sort-place-after]="dragOverIndex > 0 && dragOverIndex === site.order && draggedIndex < dragOverIndex"
                   [class.bt-sort-place-before]="dragOverIndex > 0 && dragOverIndex === site.order && draggedIndex > dragOverIndex"
-                  draggable="true"
+                  [class.bt-sort-is-dragged]="site.order === draggedIndex && hideElement"
                   (dragstart)="siteDragStart($event, site)"
                   (dragover)="dragOver($event, site)"
                   (drop)="onDrop($event)"
@@ -26,6 +27,7 @@ export class SitesComponent {
   @Select('sites') public sites$: Observable<SiteStateModel[]>;
   dragOverIndex: number|null = null;
   draggedIndex: number|null = null;
+  hideElement = false;
 
   constructor(private store: Store) { }
 
@@ -45,6 +47,12 @@ export class SitesComponent {
     }
     this.draggedIndex = +site.order;
     event.dataTransfer.dropEffect = 'move';
+
+    // Hide the element that's being dragged from the site list
+    // Use delay so we get the image as drag anchor
+    setTimeout(() => {
+      this.hideElement = true;
+    }, 10);
   }
 
   dragOver(event, site) {
@@ -65,5 +73,6 @@ export class SitesComponent {
   resetDrag() {
     this.dragOverIndex = null;
     this.draggedIndex = null;
+    this.hideElement = false;
   }
 }

--- a/editor/src/app/sites/sites.component.ts
+++ b/editor/src/app/sites/sites.component.ts
@@ -42,6 +42,7 @@ export class SitesComponent {
   siteDragStart(event, site) {
     this.draggedIndex = +site.order;
     event.dataTransfer.dropEffect = 'move';
+    event.dataTransfer.setData('text/plain', String(site.order));
 
     // Hide the element that's being dragged from the site list
     // Use delay so we get the image as drag anchor

--- a/editor/src/app/sites/sites.component.ts
+++ b/editor/src/app/sites/sites.component.ts
@@ -3,19 +3,29 @@ import { Store, Select } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { SiteStateModel } from './sites-state/site-state.model';
 import { UpdateInputFocus } from '../app-state/app.actions';
-import { CreateSiteAction } from './sites-state/sites.actions';
+import { CreateSiteAction, ReOrderSitesAction } from './sites-state/sites.actions';
 
 @Component({
   selector: 'berta-sites',
   template: `
-    <berta-site *ngFor="let site of sites$ | async"
-                [site]="site"
-                (inputFocus)="updateComponentFocus($event)"></berta-site>
+    <div class="nice" (dragend)="resetDrag()" (drop)="onDrop($event)">
+      <berta-site *ngFor="let site of sites$ | async"
+                  [class.bt-sort-place-after]="dragOverIndex === site.order && draggedIndex < dragOverIndex"
+                  [class.bt-sort-place-before]="dragOverIndex === site.order && draggedIndex > dragOverIndex"
+                  draggable="true"
+                  (dragstart)="siteDragStart($event, site)"
+                  (dragover)="dragOver($event, site)"
+                  (drop)="onDrop($event)"
+                  [site]="site"
+                  (inputFocus)="updateComponentFocus($event)"></berta-site>
+    </div>
     <button type="button" class="button" (click)="createSite()">Create new site</button>
   `
 })
 export class SitesComponent {
   @Select('sites') public sites$: Observable<SiteStateModel[]>;
+  dragOverIndex: number|null = null;
+  draggedIndex: number|null = null;
 
   constructor(private store: Store) { }
 
@@ -25,5 +35,30 @@ export class SitesComponent {
 
   createSite() {
     this.store.dispatch(CreateSiteAction);
+  }
+
+  siteDragStart(event, site) {
+    this.draggedIndex = +site.order;
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  dragOver(event, site) {
+    // For drop to work this must be prevented
+    event.preventDefault();
+    this.dragOverIndex = +site.order;
+  }
+
+  onDrop(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.draggedIndex === this.dragOverIndex) {
+      return;
+    }
+    this.store.dispatch(new ReOrderSitesAction(this.draggedIndex, this.dragOverIndex));
+  }
+
+  resetDrag() {
+    this.dragOverIndex = null;
+    this.draggedIndex = null;
   }
 }

--- a/editor/src/app/sites/sites.component.ts
+++ b/editor/src/app/sites/sites.component.ts
@@ -11,8 +11,8 @@ import { CreateSiteAction, ReOrderSitesAction } from './sites-state/sites.action
     <div class="nice" (dragend)="resetDrag()" (drop)="onDrop($event)">
       <berta-site *ngFor="let site of sites$ | async"
                   draggable="true"
-                  [class.bt-sort-place-after]="dragOverIndex > 0 && dragOverIndex === site.order && draggedIndex < dragOverIndex"
-                  [class.bt-sort-place-before]="dragOverIndex > 0 && dragOverIndex === site.order && draggedIndex > dragOverIndex"
+                  [class.bt-sort-place-after]="dragOverIndex === site.order && draggedIndex < dragOverIndex"
+                  [class.bt-sort-place-before]="dragOverIndex === site.order && draggedIndex > dragOverIndex"
                   [class.bt-sort-is-dragged]="site.order === draggedIndex && hideElement"
                   (dragstart)="siteDragStart($event, site)"
                   (dragover)="dragOver($event, site)"
@@ -40,11 +40,6 @@ export class SitesComponent {
   }
 
   siteDragStart(event, site) {
-    if (site.order === 0) {
-      // The home page is always the first one, don' t allow to move it
-      event.preventDefault();
-      return false;
-    }
     this.draggedIndex = +site.order;
     event.dataTransfer.dropEffect = 'move';
 
@@ -64,7 +59,7 @@ export class SitesComponent {
   onDrop(event) {
     event.preventDefault();
     event.stopPropagation();
-    if (this.draggedIndex === this.dragOverIndex || this.dragOverIndex === 0) {
+    if (this.draggedIndex === this.dragOverIndex) {
       return;
     }
     this.store.dispatch(new ReOrderSitesAction(this.draggedIndex, this.dragOverIndex));

--- a/editor/src/styles/_sections.scss
+++ b/editor/src/styles/_sections.scss
@@ -9,4 +9,19 @@ berta-site-sections {
 
 berta-section {
   display: block;
+  cursor: grab;
+
+  &.bt-sort-place-after {
+    border-bottom: 3rem solid $grey-10;
+  }
+
+  &.bt-sort-place-before {
+    border-top: 3rem solid $grey-10;
+  }
+
+  &.bt-sort-is-dragged {
+    height: 0;
+    overflow: hidden;
+    cursor: grabbing;
+  }
 }

--- a/editor/src/styles/_sections.scss
+++ b/editor/src/styles/_sections.scss
@@ -1,9 +1,15 @@
-berta-site-sections {
+.berta-site-sections {
   display: block;
 
   > button {
     font-size: .875em;
     margin: 1.3em;
+  }
+
+  &.bt-reordering {
+    .settings {
+      display: none;
+    }
   }
 }
 

--- a/editor/src/styles/_sites.scss
+++ b/editor/src/styles/_sites.scss
@@ -1,3 +1,5 @@
+@import 'variables';
+
 berta-sites {
   display: block;
 
@@ -9,4 +11,14 @@ berta-sites {
 
 berta-site {
   display: block;
+  transition: border-width 150ms ease-in;
+
+  &.bt-sort-place-after {
+    border-bottom: 3rem solid $grey-10;
+  }
+
+  &.bt-sort-place-before {
+    border-top: 3rem solid $grey-10;
+  }
 }
+

--- a/editor/src/styles/_sites.scss
+++ b/editor/src/styles/_sites.scss
@@ -20,5 +20,10 @@ berta-site {
   &.bt-sort-place-before {
     border-top: 3rem solid $grey-10;
   }
+
+  &.bt-sort-is-dragged {
+    height: 0;
+    overflow: hidden;
+  }
 }
 

--- a/editor/src/styles/_sites.scss
+++ b/editor/src/styles/_sites.scss
@@ -10,6 +10,7 @@ berta-sites {
 }
 
 berta-site {
+  cursor: grab;
   display: block;
   transition: border-width 150ms ease-in;
 
@@ -22,6 +23,7 @@ berta-site {
   }
 
   &.bt-sort-is-dragged {
+    cursor: grabbing;
     height: 0;
     overflow: hidden;
   }


### PR DESCRIPTION
Reorders Berta's sections with drag and drop.

## Todo
- [x] Fix drag preview image (currently showing all the sections below that match the total height of dragged section)
- [x] Add iframe reload when exiting sidebar if reorder did happen
- [x] Fix sorting: on first drag event reordering works fine, on next drag events order keeps the same

**Issue:** When dragging a section, the preview image shows much more then the section. It is because the "scroll height" of section is much larger and the invisible settings element is not `display: none` but simply invisible.