### PR TITLE
Empty xml fix

### DIFF
--- a/_api_app/app/Sites/Settings/SiteSettingsDataService.php
+++ b/_api_app/app/Sites/Settings/SiteSettingsDataService.php
@@ -319,7 +319,7 @@ class SiteSettingsDataService extends Storage
     public function get()
     {
         if (empty($this->SITE_SETTINGS)) {
-            $this->SITE_SETTINGS = $this->xmlFile2array($this->XML_FILE);
+            $this->reload();
         }
 
         return $this->SITE_SETTINGS;
@@ -546,5 +546,9 @@ class SiteSettingsDataService extends Storage
 
         $this->array2xmlFile($this->SITE_SETTINGS, $this->XML_FILE, $this->ROOT_ELEMENT);
         return $child;
+    }
+
+    public function reload() {
+        $this->SITE_SETTINGS = $this->xmlFile2array($this->XML_FILE);
     }
 }

--- a/_api_app/composer.json
+++ b/_api_app/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "berta",
+    "name": "berta-cms/berta",
     "description": "Berta CMS",
     "version": "1.2.2",
     "keywords": ["berta", "cms", "lumen"],

--- a/_api_app/tests/ExampleTest.php
+++ b/_api_app/tests/ExampleTest.php
@@ -11,10 +11,10 @@ class ExampleTest extends TestCase
      */
     public function testExample()
     {
-        $this->get('/');
+        $this->get('/v1/meta');
 
         $this->assertEquals(
-            $this->response->getContent(), $this->app->version()
+            $this->response->getStatusCode(), 200
         );
     }
 }

--- a/engine/_classes/class.settings.php
+++ b/engine/_classes/class.settings.php
@@ -65,14 +65,23 @@ class Settings
             }
 
             $xml_file = BertaBase::$options['XML_ROOT'] . $this->fileName;
-            $fp = fopen($xml_file, 'w');
+
+            // Use append flag ('a'), so we wouldn't delete the file, before lock
+            $fp = fopen($xml_file, 'a');
             if (flock($fp, LOCK_EX)) {
+                // Clear the file once we have the lock
+                ftruncate($fp, 0);
+
                 fwrite($fp, $xml);
                 @chmod($xml_file, 0666);
+
+                // Make sure everything is written to the file
+                fflush($fp);
                 flock($fp, LOCK_UN);
                 fclose($fp);
                 return true;
             } else {
+                fclose($fp);
                 throw new \Exception('Could not write locked file: ' . $xml_file);
             }
         }


### PR DESCRIPTION
- Make sure file is locked before it's written to
- Use file pointer for writing, so we can see what's going on and we use the pointer we just locked
- Make sure file has been written before we release the lock
- Make sure file is closed if we don't get the lock