### PR TITLE
$SITE_ROOT_PATH must end with a slash

### DIFF
--- a/_api_app/app/Configuration/SiteSettingsConfigService.php
+++ b/_api_app/app/Configuration/SiteSettingsConfigService.php
@@ -26,7 +26,7 @@ class SiteSettingsConfigService
         I18n::load_language($lang);
 
         $ENGINE_ROOT_PATH = config('app.old_berta_root') . '/engine/';
-        $SITE_ROOT_PATH = config('app.old_berta_root');
+        $SITE_ROOT_PATH = config('app.old_berta_root') . '/';
         $conf = file_get_contents(
             realpath(config('app.old_berta_root') . '/engine/inc.settings.php')
         );


### PR DESCRIPTION
- according to the use of this variable in code, the next peace of path is always added without the slash
- In the old version, it had slash at the end
- I can't add the slash to `app.old_berta_root` because that's used differently