### PR TITLE
Style service

### DIFF
--- a/_api_app/app/Sites/Sections/MessyTemplateRenderService.php
+++ b/_api_app/app/Sites/Sections/MessyTemplateRenderService.php
@@ -326,7 +326,16 @@ class MessyTemplateRenderService extends SectionTemplateRenderService
         if (!empty($tagSlug)) {
             $urlParts['tag'] = $tagSlug;
         }
-        $link = '/' . implode('/', $urlParts) . ($isPreviewMode ? '?preview=1' : '');
+
+        if ($isEditMode) {
+            $parts = [];
+            foreach ($urlParts as $property => $value) {
+                $parts[] = $property . '=' . $value;
+            }
+            $link = '?' . implode('&', $parts);
+        } else {
+            $link = '/' . implode('/', $urlParts) . ($isPreviewMode ? '?preview=1' : '');
+        }
 
         return [
             'attributes' => Helpers::arrayToHtmlAttributes($attributes),

--- a/_api_app/app/Sites/SitesDataService.php
+++ b/_api_app/app/Sites/SitesDataService.php
@@ -119,6 +119,8 @@ class SitesDataService extends Storage
     {
         $sites = $this->get();
         foreach ($sites as $order => $site) {
+            $sitesDS = new self($site['name']);
+            $sites[$order]['mediaUrl'] = $sitesDS->MEDIA_URL;
             $sites[$order]['order'] = $order;
         }
 

--- a/_templates/default/style.css.php
+++ b/_templates/default/style.css.php
@@ -182,7 +182,7 @@ h1 {
 
 #pageEntries li.xEntry .xGalleryContainer {
     clear: <?php echo $contentFloat ?>;
-    margin: <?php echo $contentFloat ? '0' : '0 0 0 auto' ?>;
+    margin: <?php echo $contentFloat == 'left' ? '0' : '0 0 0 auto' ?>;
 }
 
 #pageEntries li.xEntry .xGalleryContainer .xGallery {
@@ -199,7 +199,7 @@ h1 {
 
 #pageEntries .xGalleryContainer ul.xGalleryNav li {
     float: <?php echo $contentFloat ?>;
-    padding: <?php echo $contentFloat ? '0 5px 0 0' : '0 0 0 5px' ?>;
+    padding: <?php echo $contentFloat == 'left' ? '0 5px 0 0' : '0 0 0 5px' ?>;
 }
 
 #pageEntries li.xEntry .entryText {

--- a/_templates/default/template.conf.php
+++ b/_templates/default/template.conf.php
@@ -73,6 +73,12 @@ $templateConf = [
             'default' => reset($fontOptions),
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -81,6 +87,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -525,6 +537,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -533,6 +551,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -682,6 +706,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -690,6 +720,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'colorLink' => [
             'format' => 'color',
@@ -872,6 +908,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -880,6 +922,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -1062,6 +1110,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -1070,6 +1124,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -1185,6 +1245,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -1193,6 +1259,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',

--- a/_templates/default/template.conf.php
+++ b/_templates/default/template.conf.php
@@ -301,7 +301,6 @@ $templateConf = [
                     'property' => 'background-color'
                 ]
             ]
-
         ],
         'backgroundImageEnabled' => [
             'format' => 'select',

--- a/_templates/default/template.conf.php
+++ b/_templates/default/template.conf.php
@@ -618,13 +618,13 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Menu items separator'),
             'description' => '',
-            // @todo prepare value before preview with quotes around in style service: `"${style.value}"`
-            // 'css' => [
-            //     [
-            //         'selector' => '.bt-sections-menu > ul:not(.subMenu) li:not(:first-child)::before',
-            //         'property' => 'content'
-            //     ]
-            // ]
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li:not(:first-child)::before',
+                    'property' => 'content',
+                    'template' => '`"${value}"`'
+                ]
+            ]
         ],
         'separatorDistance' => [
             'format' => 'text',
@@ -808,13 +808,13 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Menu items separator'),
             'description' => '',
-            // @todo prepare value before preview with quotes around in style service: `"${style.value}"`
-            // 'css' => [
-            //     [
-            //         'selector' => '.bt-sections-menu > .subMenu li:not(:first-child)::before',
-            //         'property' => 'content'
-            //     ]
-            // ]
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li:not(:first-child)::before',
+                    'property' => 'content',
+                    'template' => '`"${value}"`'
+                ]
+            ]
         ],
         'separatorDistance' => [
             'format' => 'text',

--- a/_templates/default/template.conf.php
+++ b/_templates/default/template.conf.php
@@ -60,6 +60,12 @@ $templateConf = [
             'default' => '#333333',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -83,6 +89,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -93,6 +105,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -103,6 +121,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -113,6 +137,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -121,6 +151,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -133,24 +169,48 @@ $templateConf = [
             'default' => '#888888',
             'title' => I18n::_('Link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorVisited' => [
             'format' => 'color',
             'default' => '#888888',
             'title' => I18n::_('Visited link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#888888',
             'title' => I18n::_('Link color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#888888',
             'title' => I18n::_('Link color when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -163,6 +223,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationVisited' => [
             'format' => 'select',
@@ -175,6 +241,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Visited link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -187,6 +259,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -199,6 +277,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -211,6 +295,13 @@ $templateConf = [
             'default' => '#FFFFFF',
             'title' => I18n::_('Background color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-color'
+                ]
+            ]
+
         ],
         'backgroundImageEnabled' => [
             'format' => 'select',
@@ -309,6 +400,16 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Width of content area'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer',
+                    'property' => 'width'
+                ],
+                [
+                    'selector' => '.bt-responsive #contentContainer',
+                    'property' => 'max-width'
+                ]
+            ]
         ],
         'bodyMargin' => [
             'format' => 'text',
@@ -317,6 +418,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Page margins'),
             'description' => I18n::_('How far the content is from browser edges. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '#contentContainer',
+                    'property' => 'padding'
+                ]
+            ]
         ],
         'siteMenuMargin' => [
             'format' => 'text',
@@ -325,6 +432,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Top menu margins'),
             'description' => I18n::_('How big is the distance from the top menu to the other page elements'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu',
+                    'property' => 'padding'
+                ]
+            ]
         ],
         'group_responsive' => [
             'format' => false,
@@ -362,6 +475,32 @@ $templateConf = [
             'default' => '#333333',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#contentContainer h1 a',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#contentContainer h1 a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#contentContainer h1 a:visited',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#contentContainer h1 a:hover',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#contentContainer h1 a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -385,6 +524,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -395,6 +540,12 @@ $templateConf = [
             'default' => 'bold',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -405,6 +556,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -415,6 +572,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -423,6 +586,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'margin' => [
             'format' => 'text',
@@ -431,6 +600,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Margins'),
             'description' => I18n::_('How far the heading is from other elements in page. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => 'h1',
+                    'property' => 'margin'
+                ]
+            ]
         ],
     ],
 
@@ -444,6 +619,13 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Menu items separator'),
             'description' => '',
+            // @todo prepare value before preview with quotes around in style service: `"${style.value}"`
+            // 'css' => [
+            //     [
+            //         'selector' => '.bt-sections-menu > ul:not(.subMenu) li:not(:first-child)::before',
+            //         'property' => 'content'
+            //     ]
+            // ]
         ],
         'separatorDistance' => [
             'format' => 'text',
@@ -452,6 +634,16 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Space width around separator'),
             'description' => I18n::_('The distance from the separator to the menu item on both sides'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li:not(:first-child)::before',
+                    'property' => 'padding-left'
+                ],
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li:not(:first-child)::before',
+                    'property' => 'padding-right'
+                ],
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -460,6 +652,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -481,18 +679,44 @@ $templateConf = [
             'default' => '#888888',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu ul li a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '.bt-sections-menu ul li a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#888888',
             'title' => I18n::_('Color when hovered'),
             'description' => I18n::_('Color of the element under mouse cursor'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu ul li a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#888888',
             'title' => I18n::_('Color when selected'),
             'description' => I18n::_('Color of the element of the currently opened section'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu ul li a:active',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '.bt-sections-menu ul li.selected > a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -504,6 +728,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -515,6 +745,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -526,6 +762,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -534,6 +776,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu) li',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'margin' => [
             'format' => 'text',
@@ -542,6 +790,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Margins'),
             'description' => I18n::_('How far the menu is form other elements in page. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul:not(.subMenu)',
+                    'property' => 'padding'
+                ]
+            ]
         ],
     ],
 
@@ -555,6 +809,13 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Menu items separator'),
             'description' => '',
+            // @todo prepare value before preview with quotes around in style service: `"${style.value}"`
+            // 'css' => [
+            //     [
+            //         'selector' => '.bt-sections-menu > .subMenu li:not(:first-child)::before',
+            //         'property' => 'content'
+            //     ]
+            // ]
         ],
         'separatorDistance' => [
             'format' => 'text',
@@ -563,6 +824,16 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Space width around separator'),
             'description' => I18n::_('The distance from the separator to the menu item on both sides'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li:not(:first-child)::before',
+                    'property' => 'padding-left'
+                ],
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li:not(:first-child)::before',
+                    'property' => 'padding-right'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -571,6 +842,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -597,6 +874,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -608,6 +891,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -619,6 +908,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -627,6 +922,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu li',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'margin' => [
             'format' => 'text',
@@ -635,6 +936,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Margins'),
             'description' => I18n::_('How far the menu is form other elements in page. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > .subMenu',
+                    'property' => 'padding'
+                ]
+            ]
         ],
     ],
 
@@ -649,6 +956,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Entry margins'),
             'description' => I18n::_('Margins around entries. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry',
+                    'property' => 'margin'
+                ]
+            ]
         ],
         'galleryPosition' => [
             'format' => 'select',
@@ -678,6 +991,21 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between images in row and column'),
             'description' => I18n::_('Horizontal/vertical space between images when gallery is in "row"/"column" mode'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .xGalleryType-column .xGalleryItem',
+                    'property' => 'padding-bottom'
+                ],
+                [
+                    'selector' => '#pageEntries li.xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGalleryItem',
+                    'property' => 'margin-right'
+                ],
+                [
+                    'selector' => '.bt-responsive #pageEntries li.xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGallery .xGalleryItem',
+                    'property' => 'padding-bottom',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
         'galleryMargin' => [
             'format' => 'text',
@@ -686,6 +1014,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Gallery margins'),
             'description' => I18n::_('Margin around gallery block'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .xGalleryContainer .xGallery',
+                    'property' => 'margin'
+                ]
+            ]
         ],
     ],
 
@@ -698,6 +1032,12 @@ $templateConf = [
             'default' => '#333333',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -721,6 +1061,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -731,6 +1077,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -741,6 +1093,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -751,6 +1109,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -759,6 +1123,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'margin' => [
             'format' => 'text',
@@ -767,6 +1137,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Margins'),
             'description' => I18n::_('How far the entry heading is form other elements in page. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry h2',
+                    'property' => 'margin'
+                ]
+            ]
         ],
     ],
 
@@ -779,6 +1155,12 @@ $templateConf = [
             'default' => '#333333',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -802,6 +1184,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -813,6 +1201,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -824,6 +1218,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -835,6 +1235,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -843,6 +1249,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .entryContent',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -855,6 +1267,12 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Button color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.social-icon path',
+                    'property' => 'fill'
+                ]
+            ]
         ],
     ],
 

--- a/_templates/default/template.conf.php
+++ b/_templates/default/template.conf.php
@@ -322,6 +322,12 @@ $templateConf = [
             'affectsStyle' => true,
             'title' => I18n::_('Background image'),
             'description' => I18n::_('Picture to use for page background.'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-image'
+                ]
+            ]
         ],
         'backgroundRepeat' => [
             'format' => 'select',
@@ -334,6 +340,12 @@ $templateConf = [
             'default' => 'repeat',
             'title' => I18n::_('Background tiling'),
             'description' => I18n::_('How the background fills the screen?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-repeat'
+                ]
+            ]
         ],
         'backgroundPosition' => [
             'format' => 'select',
@@ -351,6 +363,12 @@ $templateConf = [
             'default' => 'top left',
             'title' => I18n::_('Background alignment'),
             'description' => I18n::_('Where the background image is positioned?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-position'
+                ]
+            ]
         ],
         'backgroundAttachment' => [
             'format' => 'select',

--- a/_templates/mashup-0.3.5/template.conf.php
+++ b/_templates/mashup-0.3.5/template.conf.php
@@ -587,6 +587,7 @@ $templateConf = [
                 [
                     'selector' => '#sideColumnTop h1 a',
                     'property' => 'color'
+                    // 'template' => '%s !important'
                 ]
             ]
         ],

--- a/_templates/mashup-0.3.5/template.conf.php
+++ b/_templates/mashup-0.3.5/template.conf.php
@@ -78,6 +78,12 @@ $templateConf = [
             'default' => '#1a1a1a',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -101,6 +107,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -111,6 +123,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -121,6 +139,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -131,6 +155,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -139,6 +169,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -151,24 +187,48 @@ $templateConf = [
             'default' => '#0000ff',
             'title' => I18n::_('Link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorVisited' => [
             'format' => 'color',
             'default' => '#666666',
             'title' => I18n::_('Visited link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#0000ff',
             'title' => I18n::_('Link color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#0000ff',
             'title' => I18n::_('Link color when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -181,6 +241,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationVisited' => [
             'format' => 'select',
@@ -193,6 +259,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Visited link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -205,6 +277,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -217,6 +295,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -229,6 +313,12 @@ $templateConf = [
             'default' => '#FFFFFF',
             'title' => I18n::_('Background color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-color'
+                ]
+            ]
         ],
         'backgroundImageEnabled' => [
             'format' => 'select',
@@ -329,6 +419,16 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('How far content is from sidebar?'),
             'description' => I18n::_('The horizontal distance between the menu and the content area.'),
+            'css' => [
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'padding-left'
+                ],
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'padding-right'
+                ]
+            ]
         ],
         'group_responsive' => [
             'format' => false,
@@ -411,6 +511,16 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Left margin'),
             'description' => I18n::_('How far the sidebar is from the left side of the screen. This gets ignored, if centered layout is enabled.'),
+            'css' => [
+                [
+                    'selector' => '#mainColumnContainer',
+                    'property' => 'padding-left'
+                ],
+                [
+                    'selector' => '#sideColumn',
+                    'property' => 'padding-left'
+                ]
+            ]
         ],
         'marginTop' => [
             'format' => 'text',
@@ -419,6 +529,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Top padding'),
             'description' => I18n::_('How far the header is from the top of the screen?'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop',
+                    'property' => 'padding-top'
+                ]
+            ]
         ],
         'marginBottom' => [
             'format' => 'text',
@@ -427,6 +543,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between header and menu'),
             'description' => I18n::_('How far the menu is from the header text or header image.'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
         'transparent' => [
             'format' => 'select',
@@ -457,6 +579,16 @@ $templateConf = [
             'default' => '#1a1a1a',
             'title' => I18n::_('Heading text color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop h1 a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -480,6 +612,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Heading font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -490,6 +628,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Heading font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -500,6 +644,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Heading font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -510,6 +660,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Heading font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -518,6 +674,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Heading line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -547,6 +709,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop ul li',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -557,6 +725,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop ul li',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -567,6 +741,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop ul li',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -575,24 +755,72 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop ul li',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'colorLink' => [
             'format' => 'color',
             'default' => '#1a1a1a',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop li a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop li a:visited',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#0000ff',
             'title' => I18n::_('Color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop li a:hover',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#1a1a1a',
             'title' => I18n::_('Color when opened'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop li a:active',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > a',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > span',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -605,6 +833,20 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop li a:link',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop li a:visited',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -617,6 +859,16 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop li a:hover',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -629,6 +881,24 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Decoration when opened'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop li a:active',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > a',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > span',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -658,6 +928,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -668,6 +944,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -678,6 +960,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -686,24 +974,56 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'colorLink' => [
             'format' => 'color',
             'default' => '#1a1a1a',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#0000ff',
             'title' => I18n::_('Color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#1a1a1a',
             'title' => I18n::_('Color when selected'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:active',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li.selected > a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -716,6 +1036,16 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:link',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:visited',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -728,6 +1058,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -740,6 +1076,16 @@ $templateConf = [
             'default' => 'line-through',
             'title' => I18n::_('Decoration when opened'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li a:active',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li.selected > a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -754,6 +1100,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between entries'),
             'description' => I18n::_('Distance from entry to entry. In pixels.'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
         'defaultGalleryType' => [
             'format' => 'select',
@@ -772,6 +1124,25 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between images in row and column'),
             'description' => I18n::_('Horizontal/vertical space between images when gallery is in "row"/"column" mode'),
+            'css' => [
+                [
+                    'selector' => '.xGalleryType-column div.xGalleryItem',
+                    'property' => 'padding-bottom'
+                ],
+                [
+                    'selector' => '.xGalleryType-row:not(.bt-gallery-has-one-item) .xGalleryItem',
+                    'property' => 'margin-right'
+                ],
+                [
+                    'selector' => '.xSectionType-portfolio #pageEntries li.xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGallery .xGalleryItem',
+                    'property' => 'padding-bottom'
+                ],
+                [
+                    'selector' => '.bt-responsive #pageEntries li.xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGallery .xGalleryItem',
+                    'property' => 'padding-bottom',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
         'galleryNavMargin' => [
             'format' => 'text',
@@ -780,6 +1151,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between images and image navigation'),
             'description' => I18n::_('Vertical space between images and image navigation (the digits below the image) when gallery is in "slideshow" mode'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .xGalleryType-slideshow .xGallery',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
         'galleryMargin' => [
             'format' => 'text',
@@ -788,6 +1165,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Empty space below gallery'),
             'description' => I18n::_('Distance between the gallery and the content below'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries li.xEntry .xGalleryContainer',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
     ],
 
@@ -800,6 +1183,12 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Button color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.social-icon path',
+                    'property' => 'fill'
+                ]
+            ]
         ],
     ],
 

--- a/_templates/mashup-0.3.5/template.conf.php
+++ b/_templates/mashup-0.3.5/template.conf.php
@@ -91,6 +91,12 @@ $templateConf = [
             'default' => '"Times New Roman", Times, serif',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -99,6 +105,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => I18n::_('Google web fonts'),
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -656,6 +668,12 @@ $templateConf = [
             'default' => 'Georgia, "Times New Roman", Times, serif',
             'title' => I18n::_('Heading font'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -664,6 +682,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => I18n::_('Google web fonts'),
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -753,6 +777,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop ul li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -761,6 +791,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => I18n::_('Google web fonts'),
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop ul li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -972,6 +1008,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -980,6 +1022,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => I18n::_('Google web fonts'),
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop .bt-sections-menu .subMenu li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',

--- a/_templates/mashup-0.3.5/template.conf.php
+++ b/_templates/mashup-0.3.5/template.conf.php
@@ -586,8 +586,8 @@ $templateConf = [
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a',
-                    'property' => 'color'
-                    // 'template' => '%s !important'
+                    'property' => 'color',
+                    'important' => true
                 ]
             ]
         ],

--- a/_templates/mashup-0.3.5/template.conf.php
+++ b/_templates/mashup-0.3.5/template.conf.php
@@ -340,6 +340,12 @@ $templateConf = [
             'affectsStyle' => true,
             'title' => I18n::_('Background image'),
             'description' => I18n::_('Picture to use for page background.'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-image'
+                ]
+            ]
         ],
         'backgroundRepeat' => [
             'format' => 'select',
@@ -352,6 +358,12 @@ $templateConf = [
             'default' => 'repeat',
             'title' => I18n::_('Background tiling'),
             'description' => I18n::_('How the background fills the screen?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-repeat'
+                ]
+            ]
         ],
         'backgroundPosition' => [
             'format' => 'select',
@@ -369,6 +381,12 @@ $templateConf = [
             'default' => 'top left',
             'title' => I18n::_('Background alignment'),
             'description' => I18n::_('Where the background image is positioned?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-position'
+                ]
+            ]
         ],
         'backgroundAttachment' => [
             'format' => 'select',
@@ -403,6 +421,16 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Entry text max width'),
             'description' => I18n::_('Width of texts in the entries. This does not apply to the width of images.'),
+            'css' => [
+                [
+                    'selector' => '#firstPageMarkedEntries .xEntry',
+                    'property' => 'max-width'
+                ],
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'max-width'
+                ]
+            ]
         ],
         'paddingTop' => [
             'format' => 'text',
@@ -411,6 +439,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('How far content is from page top?'),
             'description' => I18n::_('The vertical distance between the top of the page and the content area.'),
+            'css' => [
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'padding-top'
+                ]
+            ]
         ],
         'paddingLeft' => [
             'format' => 'text',
@@ -469,6 +503,13 @@ $templateConf = [
             'css_units' => false,
             'title' => I18n::_('Image size ratio'),
             'description' => I18n::_('Images in the first page layout will be resized by this ratio. Think of it as percentage, e.g., 0.7 = 70% of the original image size.'),
+            'css' => [
+                [
+                    'selector' => '.bt-responsive #firstPageMarkedEntries .xEntry',
+                    'property' => 'max-width',
+                    'template' => '`${value * 100}%`'
+                ]
+            ]
         ],
         'imageHaveShadows' => [
             'format' => 'select',
@@ -503,6 +544,24 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Width'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumn',
+                    'property' => 'width'
+                ],
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'margin-left'
+                ],
+                [
+                    'selector' => '.xNarrow #mainColumn.xCentered',
+                    'property' => 'margin-left'
+                ],
+                [
+                    'selector' => '.floating-banners',
+                    'property' => 'margin-left'
+                ],
+            ]
         ],
         'marginLeft' => [
             'format' => 'text',
@@ -518,7 +577,7 @@ $templateConf = [
                 ],
                 [
                     'selector' => '#sideColumn',
-                    'property' => 'padding-left'
+                    'property' => 'left'
                 ]
             ]
         ],

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -119,6 +119,12 @@ $templateConf = [
             'default' => 'Arial, sans-serif',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -127,6 +133,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -667,6 +679,12 @@ $templateConf = [
             'default' => '"Arial black", Gadget',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -675,6 +693,20 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'font-family'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'font-family'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -821,6 +853,12 @@ $templateConf = [
             'default' => '"Arial black", Gadget',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -829,6 +867,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -1034,6 +1078,12 @@ $templateConf = [
             'default' => '"Arial black", Gadget',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -1042,6 +1092,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -1283,6 +1339,12 @@ $templateConf = [
             'default' => 'Arial, sans-serif',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -1291,6 +1353,12 @@ $templateConf = [
             'html_entities' => true,
             'title' => 'Google web fonts',
             'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -612,13 +612,14 @@ $templateConf = [
             'default' => 'absolute',
             'title' => I18n::_('Heading position'),
             'description' => I18n::_('description_heading_position'),
-            'css' => [
-                [
-                    'selector' => '#contentContainer h1',
-                    'property' => 'position',
-                    'important' => true
-                ]
-            ]
+            // @todo Fix the positing calculation in js. For now reload is required.
+            // 'css' => [
+            //     [
+            //         'selector' => '#contentContainer h1',
+            //         'property' => 'position',
+            //         'important' => true
+            //     ]
+            // ]
         ],
         'image' => [
             'format' => 'image',
@@ -839,13 +840,14 @@ $templateConf = [
             'default' => 'absolute',
             'title' => I18n::_('Menu position'),
             'description' => I18n::_('description_menu_position'),
-            'css' => [
-                [
-                    'selector' => '.bt-sections-menu > ul > li',
-                    'property' => 'position',
-                    'important' => true
-                ]
-            ]
+            // @todo Fix the positing calculation in js. For now reload is required.
+            // 'css' => [
+            //     [
+            //         'selector' => '.bt-sections-menu > ul > li',
+            //         'property' => 'position',
+            //         'important' => true
+            //     ]
+            // ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -1319,6 +1319,14 @@ $templateConf = [
                 [
                     'selector' => '#pageEntries .xEntry h2',
                     'property' => 'font-weight'
+                ],
+                [
+                    'selector' => '#shoppingCartTitle',
+                    'property' => 'font-weight'
+                ],
+                [
+                    'selector' => '#shoppingCartEmpty',
+                    'property' => 'font-weight'
                 ]
             ]
         ],
@@ -1335,6 +1343,14 @@ $templateConf = [
                 [
                     'selector' => '#pageEntries .xEntry h2',
                     'property' => 'font-style'
+                ],
+                [
+                    'selector' => '#shoppingCartTitle',
+                    'property' => 'font-style'
+                ],
+                [
+                    'selector' => '#shoppingCartEmpty',
+                    'property' => 'font-style'
                 ]
             ]
         ],
@@ -1350,6 +1366,14 @@ $templateConf = [
             'css' => [
                 [
                     'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-variant'
+                ],
+                [
+                    'selector' => '#shoppingCartTitle',
+                    'property' => 'font-variant'
+                ],
+                [
+                    'selector' => '#shoppingCartEmpty',
                     'property' => 'font-variant'
                 ]
             ]

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -106,6 +106,12 @@ $templateConf = [
             'default' => '#363636',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -129,6 +135,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -139,6 +151,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -149,6 +167,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -159,6 +183,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -167,6 +197,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -179,24 +215,48 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorVisited' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Visited link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Link color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Link color when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -209,6 +269,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationVisited' => [
             'format' => 'select',
@@ -221,6 +287,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Visited link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -233,6 +305,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -245,6 +323,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -257,6 +341,12 @@ $templateConf = [
             'default' => '#FFFFFF',
             'title' => I18n::_('Background color'),
             'description' => I18n::_('IMPORTANT! These settings will be overwritten, if you are using background gallery feature. You access it by clicking "edit background gallery" button in each section.'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-color'
+                ]
+            ]
         ],
         'backgroundImageEnabled' => [
             'format' => 'select',
@@ -369,6 +459,29 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true, 'title' => I18n::_('Centered content width'),
             'description' => I18n::_('Content width if layout is centered.'),
+            'css' => [
+                [
+                    'selector' => 'body:not(.bt-responsive):not(.bt-auto-responsive) #contentContainer.xCentered',
+                    'property' => 'width'
+                ],
+                [
+                    'selector' => '.xCenteringGuide',
+                    'property' => 'width'
+                ],
+                [
+                    'selector' => '.bt-responsive #contentContainer',
+                    'property' => 'max-width'
+                ],
+                [
+                    'selector' => '.bt-auto-responsive #contentContainer.xCentered',
+                    'property' => 'max-width'
+                ],
+                [
+                    'selector' => '.bt-auto-responsive #contentContainer',
+                    'property' => 'max-width',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
         'centeringGuidesColor' => [
             'format' => 'select',
@@ -420,6 +533,17 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Heading margin'),
             'description' => I18n::_('Margin around page heading or logo. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '.bt-responsive #contentContainer h1',
+                    'property' => 'margin'
+                ],
+                [
+                    'selector' => '.bt-auto-responsive #contentContainer h1',
+                    'property' => 'margin',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
         'menuMargin' => [
             'format' => 'text',
@@ -427,6 +551,21 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Menu margin'),
             'description' => I18n::_('Margin around menu. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '.portfolioThumbnailsWrap',
+                    'property' => 'margin'
+                ],
+                [
+                    'selector' => '.bt-responsive .bt-sections-menu',
+                    'property' => 'margin'
+                ],
+                [
+                    'selector' => '.bt-auto-responsive .bt-sections-menu',
+                    'property' => 'margin',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
     ],
 
@@ -443,6 +582,13 @@ $templateConf = [
             'default' => 'absolute',
             'title' => I18n::_('Heading position'),
             'description' => I18n::_('description_heading_position'),
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'position',
+                    // 'template' => '%s !important'
+                ]
+            ]
         ],
         'image' => [
             'format' => 'image',
@@ -457,6 +603,45 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => 'h1 a',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => 'h1 a:link',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => 'h1 a:visited',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => 'h1 a:hover',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => 'h1 a:active',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -480,6 +665,20 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'font-size'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'font-size'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -490,6 +689,20 @@ $templateConf = [
             'default' => 'bold',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'font-weight'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'font-weight'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -500,6 +713,20 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'font-style'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'font-style'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -510,6 +737,20 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'font-variant'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'font-variant'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -518,6 +759,20 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#contentContainer h1',
+                    'property' => 'line-height'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundRightCounter',
+                    'property' => 'line-height'
+                ],
+                [
+                    'selector' => '#xBackground #xBackgroundLeftCounter',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -534,6 +789,13 @@ $templateConf = [
             'default' => 'absolute',
             'title' => I18n::_('Menu position'),
             'description' => I18n::_('description_menu_position'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'position',
+                    // 'template' => '%s !important'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -557,6 +819,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -567,6 +835,12 @@ $templateConf = [
             'default' => 'bold',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -577,6 +851,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -585,24 +865,69 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'colorLink' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:visited',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#pageEntries .xEntry .xGalleryContainer ul.xGalleryNav a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Color when hovered'),
             'description' => I18n::_('Color of the element under mouse cursor'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:hover',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:active',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Color when selected'),
             'description' => I18n::_('Color of the element of the currently opened section'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li.selected > a',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -615,6 +940,20 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:link',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:visited',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#pageEntries .xEntry .xGalleryContainer ul.xGalleryNav a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -627,6 +966,20 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:hover',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '.bt-sections-menu > ul > li a:active',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -639,6 +992,17 @@ $templateConf = [
             'default' => 'line-through',
             'title' => I18n::_('Decoration when selected'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu > ul > li.selected > a',
+                    'property' => 'text-decoration',
+                    // 'template' => '%s !important'
+                ],
+                [
+                    'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -668,6 +1032,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -678,6 +1048,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -688,6 +1064,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -696,24 +1078,57 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'colorLink' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:hover',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#000000',
             'title' => I18n::_('Color when selected'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li.selected > a',
+                    'property' => 'color',
+                    // 'template' => '%s !important'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -726,6 +1141,16 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:link',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:visited',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -738,6 +1163,16 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:hover',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '.bt-sections-menu .subMenu li a:active',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -750,6 +1185,13 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Decoration when selected'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu li.selected > a',
+                    'property' => 'text-decoration',
+                    // 'template' => '%s !important'
+                ]
+            ]
         ],
         'x' => [
             'format' => 'text',
@@ -758,6 +1200,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Positon X'),
             'description' => I18n::_('description_tagsMenu_x'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu',
+                    'property' => 'left'
+                ]
+            ]
         ],
         'y' => [
             'format' => 'text',
@@ -766,6 +1214,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Positon Y'),
             'description' => I18n::_('description_tagsMenu_y'),
+            'css' => [
+                [
+                    'selector' => '.bt-sections-menu .subMenu',
+                    'property' => 'top'
+                ]
+            ]
         ],
         'alwaysOpen' => [
             'format' => 'select',
@@ -798,6 +1252,12 @@ $templateConf = [
             'default' => '#363636',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -821,6 +1281,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -831,6 +1297,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -841,6 +1313,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -851,6 +1329,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -859,12 +1343,24 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
             'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'margin' => [
             'format' => 'text',
             'default' => '15px 0 15px 0',
             'title' => I18n::_('Margins'),
             'description' => I18n::_('How far the entry heading is form other elements in page. Please see the short CSS guide at the bottom of this page.'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'margin'
+                ]
+            ]
         ],
     ],
 
@@ -897,6 +1393,26 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between images in row and column'),
             'description' => I18n::_('Horizontal/vertical space between images when gallery is in "row"/"column" mode'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry .xGalleryType-column .xGalleryItem',
+                    'property' => 'padding-bottom'
+                ],
+                [
+                    'selector' => '#pageEntries .xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGalleryItem',
+                    'property' => 'margin-right'
+                ],
+                [
+                    'selector' => '.bt-responsive #pageEntries .xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGallery .xGalleryItem',
+                    'property' => 'padding-bottom',
+                    'breakpoint' => '(max-width: 767px)'
+                ],
+                [
+                    'selector' => '.bt-auto-responsive #pageEntries .xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGallery .xGalleryItem',
+                    'property' => 'padding-bottom',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
         'galleryNavMargin' => [
             'format' => 'text',
@@ -905,6 +1421,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Space between images and image navigation'),
             'description' => I18n::_('Vertical space between images and image navigation (the digits below the image) when gallery is in "slideshow" mode'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry .xGalleryType-slideshow .xGallery',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
         'galleryMargin' => [
             'format' => 'text',
@@ -913,6 +1435,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Empty space below gallery'),
             'description' => I18n::_('Distance between the gallery and the content below'),
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry .xGalleryContainer',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
     ],
 
@@ -925,6 +1453,12 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Button color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.social-icon path',
+                    'property' => 'fill'
+                ]
+            ]
         ],
     ],
 

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -368,6 +368,12 @@ $templateConf = [
             'affectsStyle' => true,
             'title' => I18n::_('Background image'),
             'description' => I18n::_('Picture to use for page background.'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-image'
+                ]
+            ]
         ],
         'backgroundRepeat' => [
             'format' => 'select',
@@ -380,6 +386,12 @@ $templateConf = [
             'default' => 'repeat',
             'title' => I18n::_('Background tiling'),
             'description' => I18n::_('How the background fills the screen?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-repeat'
+                ]
+            ]
         ],
         'backgroundPosition' => [
             'format' => 'select',
@@ -397,6 +409,12 @@ $templateConf = [
             'default' => 'top left',
             'title' => I18n::_('Background alignment'),
             'description' => I18n::_('Where the background image is positioned?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-position'
+                ]
+            ]
         ],
         'backgroundAttachment' => [
             'format' => 'select',
@@ -1375,6 +1393,16 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Entry text max width'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#pageEntries .xEntry',
+                    'property' => 'max-width'
+                ],
+                [
+                    'selector' => '#xBackground .visual-caption',
+                    'property' => 'width'
+                ]
+            ]
         ],
         'defaultGalleryType' => [
             'format' => 'select',

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -586,7 +586,7 @@ $templateConf = [
                 [
                     'selector' => '#contentContainer h1',
                     'property' => 'position',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ]
             ]
         ],
@@ -611,27 +611,27 @@ $templateConf = [
                 [
                     'selector' => 'h1 a',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => 'h1 a:link',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => 'h1 a:visited',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => 'h1 a:hover',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => 'h1 a:active',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => '#xBackground #xBackgroundRightCounter',
@@ -793,7 +793,7 @@ $templateConf = [
                 [
                     'selector' => '.bt-sections-menu > ul > li',
                     'property' => 'position',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ]
             ]
         ],
@@ -921,7 +921,7 @@ $templateConf = [
                 [
                     'selector' => '.bt-sections-menu > ul > li.selected > a',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
@@ -996,7 +996,7 @@ $templateConf = [
                 [
                     'selector' => '.bt-sections-menu > ul > li.selected > a',
                     'property' => 'text-decoration',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ],
                 [
                     'selector' => '#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
@@ -1126,7 +1126,7 @@ $templateConf = [
                 [
                     'selector' => '.bt-sections-menu .subMenu li.selected > a',
                     'property' => 'color',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ]
             ]
         ],
@@ -1189,7 +1189,7 @@ $templateConf = [
                 [
                     'selector' => '.bt-sections-menu .subMenu li.selected > a',
                     'property' => 'text-decoration',
-                    // 'template' => '%s !important'
+                    'important' => true
                 ]
             ]
         ],

--- a/_templates/messy-0.4.2/template.conf.php
+++ b/_templates/messy-0.4.2/template.conf.php
@@ -1343,6 +1343,14 @@ $templateConf = [
                 [
                     'selector' => '#pageEntries .xEntry h2',
                     'property' => 'font-family'
+                ],
+                [
+                    'selector' => '#shoppingCartTitle',
+                    'property' => 'font-family'
+                ],
+                [
+                    'selector' => '#shoppingCartEmpty',
+                    'property' => 'font-family'
                 ]
             ]
         ],
@@ -1356,6 +1364,14 @@ $templateConf = [
             'css' => [
                 [
                     'selector' => '#pageEntries .xEntry h2',
+                    'property' => 'font-family'
+                ],
+                [
+                    'selector' => '#shoppingCartTitle',
+                    'property' => 'font-family'
+                ],
+                [
+                    'selector' => '#shoppingCartEmpty',
                     'property' => 'font-family'
                 ]
             ]

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -454,22 +454,27 @@ $templateConf = [
                 [
                     'selector' => '#sideColumnTop h1 a',
                     'property' => 'color'
+                    // 'template' => '%s !important'
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:link',
                     'property' => 'color'
+                    // 'template' => '%s !important'
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:visited',
                     'property' => 'color'
+                    // 'template' => '%s !important'
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:hover',
                     'property' => 'color'
+                    // 'template' => '%s !important'
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:active',
                     'property' => 'color'
+                    // 'template' => '%s !important'
                 ]
             ]
         ],

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -320,7 +320,13 @@ $templateConf = [
             'max_height' => 3000,
             'affectsStyle' => true,
             'title' => I18n::_('Background image'),
-            'description' => I18n::_('Picture to use for page background.')
+            'description' => I18n::_('Picture to use for page background.'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-image'
+                ]
+            ]
         ],
         'backgroundRepeat' => [
             'format' => 'select',
@@ -332,7 +338,13 @@ $templateConf = [
             ],
             'default' => 'repeat',
             'title' => I18n::_('Background tiling'),
-            'description' => I18n::_('How the background fills the screen?')
+            'description' => I18n::_('How the background fills the screen?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-repeat'
+                ]
+            ]
         ],
         'backgroundPosition' => [
             'format' => 'select',
@@ -349,7 +361,13 @@ $templateConf = [
             ],
             'default' => 'top left',
             'title' => I18n::_('Background alignment'),
-            'description' => I18n::_('Where the background image is positioned?')
+            'description' => I18n::_('Where the background image is positioned?'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-position'
+                ]
+            ]
         ],
         'backgroundAttachment' => [
             'format' => 'select',

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -591,7 +591,6 @@ $templateConf = [
                     'property' => 'margin-bottom'
                 ]
             ]
-
         ],
     ],
 

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -59,6 +59,12 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -210,6 +216,12 @@ $templateConf = [
             'default' => '#FFFFFF',
             'title' => I18n::_('Background color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'background-color'
+                ]
+            ]
         ],
         'backgroundImageEnabled' => [
             'format' => 'select',

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -402,7 +402,13 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('Entry text max width'),
-            'description' => I18n::_('Width of texts in the entries. This does not apply to the width of images.')
+            'description' => I18n::_('Width of texts in the entries. This does not apply to the width of images.'),
+            'css' => [
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'max-width'
+                ]
+            ]
         ],
         'paddingTop' => [
             'format' => 'text',
@@ -410,7 +416,13 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('How far content is from page top?'),
-            'description' => I18n::_('The vertical distance between the top of the page and the content area.')
+            'description' => I18n::_('The vertical distance between the top of the page and the content area.'),
+            'css' => [
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'padding-top'
+                ]
+            ]
         ],
         'paddingLeft' => [
             'format' => 'text',
@@ -418,7 +430,31 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('How far content is from menu?'),
-            'description' => I18n::_('The horizontal distance between the menu and the content area.')
+            'description' => I18n::_('The horizontal distance between the menu and the content area.'),
+            'css' => [
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'padding-left'
+                ],
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'padding-right'
+                ],
+                [
+                    'selector' => '.floating-banners',
+                    'property' => 'padding-left'
+                ],
+                [
+                    'selector' => '.bt-responsive #sideColumn',
+                    'property' => 'padding-left',
+                    'breakpoint' => '(max-width: 767px)'
+                ],
+                [
+                    'selector' => '.bt-responsive #sideColumnBottom',
+                    'property' => 'padding-left',
+                    'breakpoint' => '(max-width: 767px)'
+                ]
+            ]
         ],
         'leftColumnWidth' => [
             'format' => 'text',
@@ -427,6 +463,24 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Width of the left column'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumn',
+                    'property' => 'width'
+                ],
+                [
+                    'selector' => '#mainColumn',
+                    'property' => 'margin-left'
+                ],
+                [
+                    'selector' => '.xNarrow #mainColumn.xCentered',
+                    'property' => 'margin-left'
+                ],
+                [
+                    'selector' => '.floating-banners',
+                    'property' => 'margin-left'
+                ],
+            ]
         ],
         'group_responsive' => [
             'format' => false,

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -88,6 +88,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -98,6 +104,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -108,6 +120,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -118,6 +136,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -125,7 +149,13 @@ $templateConf = [
             'default' => 'normal',
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
-            'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"')
+            'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
     ],
 
@@ -138,24 +168,48 @@ $templateConf = [
             'default' => '#666666',
             'title' => I18n::_('Link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorVisited' => [
             'format' => 'color',
             'default' => '#666666',
             'title' => I18n::_('Visited link color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#666666',
             'title' => I18n::_('Link color when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#666666',
             'title' => I18n::_('Link color when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -168,6 +222,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:link',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationVisited' => [
             'format' => 'select',
@@ -180,6 +240,12 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Visited link decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:visited',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -192,6 +258,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -204,6 +276,12 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Link decoration when clicked'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'a:active',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -368,6 +446,32 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop h1 a',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop h1 a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop h1 a:visited',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop h1 a:hover',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop h1 a:active',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'fontFamily' => [
             'format' => 'fontselect',
@@ -391,6 +495,12 @@ $templateConf = [
             'allow_blank' => true,
             'title' => I18n::_('Font size'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-size'
+                ]
+            ]
         ],
         'fontWeight' => [
             'format' => 'select',
@@ -401,6 +511,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font weight'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-weight'
+                ]
+            ]
         ],
         'fontStyle' => [
             'format' => 'select',
@@ -411,6 +527,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font style'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-style'
+                ]
+            ]
         ],
         'fontVariant' => [
             'format' => 'select',
@@ -421,6 +543,12 @@ $templateConf = [
             'default' => 'normal',
             'title' => I18n::_('Font variant'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-variant'
+                ]
+            ]
         ],
         'lineHeight' => [
             'format' => 'text',
@@ -428,7 +556,13 @@ $templateConf = [
             'default' => '1em',
             'allow_blank' => true,
             'title' => I18n::_('Line height'),
-            'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"')
+            'description' => I18n::_('Height of text line. Use em, px or % values or the default value "normal"'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'line-height'
+                ]
+            ]
         ],
         'marginTop' => [
             'format' => 'text',
@@ -437,6 +571,12 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Empty space on top'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'margin-top'
+                ]
+            ]
         ],
         'marginBottom' => [
             'format' => 'text',
@@ -445,6 +585,13 @@ $templateConf = [
             'css_units' => true,
             'title' => I18n::_('Empty space on bottom'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'margin-bottom'
+                ]
+            ]
+
         ],
     ],
 
@@ -457,18 +604,61 @@ $templateConf = [
             'default' => '#666666',
             'title' => I18n::_('Color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop a:link',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop a:visited',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => 'ol#pageEntries .xGalleryContainer ul.xGalleryNav li a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorHover' => [
             'format' => 'color',
             'default' => '#666666',
             'title' => I18n::_('Color when hovered'),
-            'description' => I18n::_('Color of the element under mouse cursor')
+            'description' => I18n::_('Color of the element under mouse cursor'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop a:hover',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => 'ol#pageEntries .xGalleryContainer ul.xGalleryNav li a:hover',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'colorActive' => [
             'format' => 'color',
             'default' => '#666666',
             'title' => I18n::_('Color when selected'),
-            'description' => I18n::_('Color of the element of the currently opened section')
+            'description' => I18n::_('Color of the element of the currently opened section'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop a:active',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > a',
+                    'property' => 'color'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > span',
+                    'property' => 'color'
+                ],
+
+                [
+                    'selector' => 'ol#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
+                    'property' => 'color'
+                ]
+            ]
         ],
         'textDecorationLink' => [
             'format' => 'select',
@@ -481,6 +671,20 @@ $templateConf = [
             'default' => 'none',
             'title' => I18n::_('Decoration'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop a:link',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop a:visited',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => 'ol#pageEntries .xGalleryContainer ul.xGalleryNav li a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationHover' => [
             'format' => 'select',
@@ -493,6 +697,16 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Decoration when hovered'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop a:hover',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => 'ol#pageEntries .xGalleryContainer ul.xGalleryNav li a:hover',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
         'textDecorationActive' => [
             'format' => 'select',
@@ -505,6 +719,24 @@ $templateConf = [
             'default' => 'underline',
             'title' => I18n::_('Decoration when selected'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop a:active',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > a',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => '#sideColumnTop li.selected > span',
+                    'property' => 'text-decoration'
+                ],
+                [
+                    'selector' => 'ol#pageEntries .xGalleryContainer ul.xGalleryNav li.selected a',
+                    'property' => 'text-decoration'
+                ]
+            ]
         ],
     ],
 
@@ -518,7 +750,13 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('Space between entries'),
-            'description' => I18n::_('Distance from entry to entry. In pixels.')
+            'description' => I18n::_('Distance from entry to entry. In pixels.'),
+            'css' => [
+                [
+                    'selector' => 'ol#pageEntries li.xEntry',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
         'defaultGalleryType' => [
             'format' => 'select',
@@ -536,7 +774,21 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('Space between images in row and column'),
-            'description' => I18n::_('Horizontal/vertical space between images when gallery is in "row"/"column" mode')
+            'description' => I18n::_('Horizontal/vertical space between images when gallery is in "row"/"column" mode'),
+            'css' => [
+                [
+                    'selector' => 'ol#pageEntries li.xEntry .xGalleryType-column .xGalleryItem',
+                    'property' => 'padding-bottom'
+                ],
+                [
+                    'selector' => 'ol#pageEntries li.xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGalleryItem',
+                    'property' => 'margin-right'
+                ],
+                [
+                    'selector' => '.bt-responsive ol#pageEntries li.xEntry .xGalleryType-row:not(.bt-gallery-has-one-item) .xGallery .xGalleryItem',
+                    'property' => 'padding-bottom'
+                ]
+            ]
         ],
         'galleryNavMargin' => [
             'format' => 'text',
@@ -544,7 +796,13 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('Space between images and image navigation'),
-            'description' => I18n::_('Vertical space between images and image navigation (the digits below the image) when gallery is in "slideshow" mode')
+            'description' => I18n::_('Vertical space between images and image navigation (the digits below the image) when gallery is in "slideshow" mode'),
+            'css' => [
+                [
+                    'selector' => 'ol#pageEntries li.xEntry .xGalleryType-slideshow .xGallery',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
         'galleryMargin' => [
             'format' => 'text',
@@ -552,7 +810,13 @@ $templateConf = [
             'allow_blank' => true,
             'css_units' => true,
             'title' => I18n::_('Empty space below gallery'),
-            'description' => I18n::_('Distance between the gallery and the content below')
+            'description' => I18n::_('Distance between the gallery and the content below'),
+            'css' => [
+                [
+                    'selector' => 'ol#pageEntries li.xEntry .xGalleryContainer',
+                    'property' => 'margin-bottom'
+                ]
+            ]
         ],
     ],
 
@@ -565,6 +829,12 @@ $templateConf = [
             'default' => '#000000',
             'title' => I18n::_('Button color'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '.social-icon path',
+                    'property' => 'fill'
+                ]
+            ]
         ],
     ],
 

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -453,28 +453,28 @@ $templateConf = [
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a',
-                    'property' => 'color'
-                    // 'template' => '%s !important'
+                    'property' => 'color',
+                    'important' => true
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:link',
-                    'property' => 'color'
-                    // 'template' => '%s !important'
+                    'property' => 'color',
+                    'important' => true
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:visited',
-                    'property' => 'color'
-                    // 'template' => '%s !important'
+                    'property' => 'color',
+                    'important' => true
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:hover',
-                    'property' => 'color'
-                    // 'template' => '%s !important'
+                    'property' => 'color',
+                    'important' => true
                 ],
                 [
                     'selector' => '#sideColumnTop h1 a:active',
-                    'property' => 'color'
-                    // 'template' => '%s !important'
+                    'property' => 'color',
+                    'important' => true
                 ]
             ]
         ],

--- a/_templates/white-0.3.5/template.conf.php
+++ b/_templates/white-0.3.5/template.conf.php
@@ -72,6 +72,12 @@ $templateConf = [
             'default' => 'Arial, sans-serif',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -79,7 +85,13 @@ $templateConf = [
             'allow_blank' => true,
             'html_entities' => true,
             'title' => 'Google web fonts',
-            'description' => I18n::_('googleFont_description')
+            'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => 'body',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',
@@ -556,6 +568,12 @@ $templateConf = [
             'default' => 'inherit',
             'title' => I18n::_('Font face'),
             'description' => '',
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'googleFont' => [
             'format' => 'text',
@@ -563,7 +581,13 @@ $templateConf = [
             'allow_blank' => true,
             'html_entities' => true,
             'title' => 'Google web fonts',
-            'description' => I18n::_('googleFont_description')
+            'description' => I18n::_('googleFont_description'),
+            'css' => [
+                [
+                    'selector' => '#sideColumnTop h1',
+                    'property' => 'font-family'
+                ]
+            ]
         ],
         'fontSize' => [
             'format' => 'text',

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -11935,6 +11935,11 @@
         }
       }
     },
+    "webfontloader": {
+      "version": "1.6.28",
+      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+      "integrity": "sha1-23hhKSU8tujq5UwvsF+HCvZnW64="
+    },
     "webpack": {
       "version": "4.30.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.30.0.tgz",

--- a/editor/package.json
+++ b/editor/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.10",
     "ngx-color-picker": "^6.6.3",
     "rxjs": "^6.5.2",
+    "webfontloader": "^1.6.28",
     "zone.js": "^0.9.1"
   },
   "devDependencies": {

--- a/editor/src/app/app.module.ts
+++ b/editor/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { SentryErrorHandler } from './sentry.error-handler';
 import { StyleService } from './preview/style.service';
 import { WhiteTemplateStyleService } from './preview/white-template-style.service';
 import { DefaultTemplateStyleService } from './preview/default-template-style.service';
+import { MashupTemplateStyleService } from './preview/mashup-template-style.service';
 
 
 @NgModule({
@@ -64,6 +65,7 @@ import { DefaultTemplateStyleService } from './preview/default-template-style.se
     StyleService,
     WhiteTemplateStyleService,
     DefaultTemplateStyleService,
+    MashupTemplateStyleService,
     {provide: ErrorHandler, useClass: SentryErrorHandler}
   ],
   bootstrap: [AppComponent]

--- a/editor/src/app/app.module.ts
+++ b/editor/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { ErrorState } from './error-state/error.state';
 import { SharedModule } from './shared/shared.module';
 import { SentryErrorHandler } from './sentry.error-handler';
 import { StyleService } from './preview/style.service';
+import { WhiteTemplateStyleService } from './preview/white-template-style.service';
 
 
 @NgModule({
@@ -60,6 +61,7 @@ import { StyleService } from './preview/style.service';
   ],
   providers: [
     StyleService,
+    WhiteTemplateStyleService,
     {provide: ErrorHandler, useClass: SentryErrorHandler}
   ],
   bootstrap: [AppComponent]

--- a/editor/src/app/app.module.ts
+++ b/editor/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { StyleService } from './preview/style.service';
 import { WhiteTemplateStyleService } from './preview/white-template-style.service';
 import { DefaultTemplateStyleService } from './preview/default-template-style.service';
 import { MashupTemplateStyleService } from './preview/mashup-template-style.service';
+import { MessyTemplateStyleService } from './preview/messy-template-style.service';
 
 
 @NgModule({
@@ -66,6 +67,7 @@ import { MashupTemplateStyleService } from './preview/mashup-template-style.serv
     WhiteTemplateStyleService,
     DefaultTemplateStyleService,
     MashupTemplateStyleService,
+    MessyTemplateStyleService,
     {provide: ErrorHandler, useClass: SentryErrorHandler}
   ],
   bootstrap: [AppComponent]

--- a/editor/src/app/app.module.ts
+++ b/editor/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { PopupComponent } from './popup/popup.component';
 import { ErrorState } from './error-state/error.state';
 import { SharedModule } from './shared/shared.module';
 import { SentryErrorHandler } from './sentry.error-handler';
+import { StyleService } from './preview/style.service';
 
 
 @NgModule({
@@ -58,6 +59,7 @@ import { SentryErrorHandler } from './sentry.error-handler';
     SitesSharedModule
   ],
   providers: [
+    StyleService,
     {provide: ErrorHandler, useClass: SentryErrorHandler}
   ],
   bootstrap: [AppComponent]

--- a/editor/src/app/app.module.ts
+++ b/editor/src/app/app.module.ts
@@ -28,6 +28,7 @@ import { SharedModule } from './shared/shared.module';
 import { SentryErrorHandler } from './sentry.error-handler';
 import { StyleService } from './preview/style.service';
 import { WhiteTemplateStyleService } from './preview/white-template-style.service';
+import { DefaultTemplateStyleService } from './preview/default-template-style.service';
 
 
 @NgModule({
@@ -62,6 +63,7 @@ import { WhiteTemplateStyleService } from './preview/white-template-style.servic
   providers: [
     StyleService,
     WhiteTemplateStyleService,
+    DefaultTemplateStyleService,
     {provide: ErrorHandler, useClass: SentryErrorHandler}
   ],
   bootstrap: [AppComponent]

--- a/editor/src/app/preview/default-template-style.service.ts
+++ b/editor/src/app/preview/default-template-style.service.ts
@@ -1,0 +1,165 @@
+import { Injectable } from '@angular/core';
+import { SettingsGroupModel } from '../shared/interfaces';
+import { SiteStateModel } from '../sites/sites-state/site-state.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DefaultTemplateStyleService {
+
+  constructor() { }
+
+  getCSSList(style, cssList, site: SiteStateModel, templateSettings: SettingsGroupModel[]) {
+    if (style.group === 'background' && style.slug === 'backgroundImageEnabled') {
+      const isBackgroundImageEnabled = style.value === 'yes';
+      const backgroundImage = this.getSettingValue(templateSettings, 'background', 'backgroundImage');
+
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-image',
+          value: isBackgroundImageEnabled && backgroundImage ? `url(${site.mediaUrl}/${backgroundImage})` : 'none'
+        }
+      );
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundImage') {
+      const isBackgroundImageEnabled = this.getSettingValue(templateSettings, 'background', 'backgroundImageEnabled') === 'yes';
+      cssList = cssList.map(item => {
+        return {
+          ...item,
+          value: isBackgroundImageEnabled && style.value ? `url(${site.mediaUrl}/${style.value})` : 'none'
+        };
+      });
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundAttachment') {
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-attachment',
+          value: style.value === 'fill' ? 'fixed' : style.value
+        }
+      );
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-size',
+          value: style.value === 'fill' ? 'cover' : 'auto'
+        }
+      );
+    }
+
+    if (style.group === 'pageLayout' && style.slug === 'contentPosition') {
+      cssList.push(
+        {
+          selector: '#contentContainer',
+          property: 'margin-left',
+          value: style.value === 'left' ? '0' : 'auto'
+        }
+      );
+      cssList.push(
+        {
+          selector: '#contentContainer',
+          property: 'margin-right',
+          value: style.value === 'right' ? '0' : 'auto'
+        }
+      );
+    }
+
+    if (style.group === 'pageLayout' && style.slug === 'contentAlign') {
+      const contentFloat = style.value.endsWith('left') ? 'left' : 'right';
+      const contentTextAlign = style.value.startsWith('justify') ? 'justify' : style.value;
+
+      cssList = [...cssList, ...[
+        {
+          selector: 'body',
+          property: 'text-align',
+          value: contentFloat
+        },
+        {
+          selector: 'h1',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '.bt-sections-menu ul',
+          property: 'text-align',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries',
+          property: 'margin',
+          value: contentFloat === 'left' ? '0' : '0 0 0 auto'
+        },
+        {
+          selector: '#pageEntries li.xEntry h2',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry p.shortDesc',
+          property: 'clear',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry .xGalleryContainer',
+          property: 'clear',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry .xGalleryContainer',
+          property: 'margin',
+          value: contentFloat === 'left' ? '0' : '0 0 0 auto'
+        },
+        {
+          selector: '#pageEntries .xGalleryContainer ul.xGalleryNav li',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries .xGalleryContainer ul.xGalleryNav li',
+          property: 'padding',
+          value: contentFloat === 'left' ? '0 5px 0 0' : '0 0 0 5px'
+        },
+        {
+          selector: '#pageEntries li.xEntry .entryText',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry .entryContent table',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry .entryContent .items',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry .entryContent p.itm',
+          property: 'float',
+          value: contentFloat
+        },
+        {
+          selector: '#pageEntries li.xEntry .entryContent .tagsList div',
+          property: 'float',
+          value: contentFloat,
+          important: true
+        },
+        {
+          selector: '#pageEntries li.xEntry .entryText',
+          property: 'text-align',
+          value: contentTextAlign
+        }
+      ]];
+    }
+
+    return cssList;
+  }
+
+  getSettingValue(templateSettings: SettingsGroupModel[], group: string, slug: string) {
+    return templateSettings.find(g => g.slug === group).settings.find(s => s.slug === slug).value;
+  }
+}

--- a/editor/src/app/preview/mashup-template-style.service.ts
+++ b/editor/src/app/preview/mashup-template-style.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import { SettingsGroupModel } from '../shared/interfaces';
+import { SiteStateModel } from '../sites/sites-state/site-state.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MashupTemplateStyleService {
+
+  constructor() { }
+
+  getCSSList(style, cssList, site: SiteStateModel, templateSettings: SettingsGroupModel[]) {
+    if (style.group === 'background' && style.slug === 'backgroundImageEnabled') {
+      const isBackgroundImageEnabled = style.value === 'yes';
+      const backgroundImage = this.getSettingValue(templateSettings, 'background', 'backgroundImage');
+
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-image',
+          value: isBackgroundImageEnabled && backgroundImage ? `url(${site.mediaUrl}/${backgroundImage})` : 'none'
+        }
+      );
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundImage') {
+      const isBackgroundImageEnabled = this.getSettingValue(templateSettings, 'background', 'backgroundImageEnabled') === 'yes';
+      cssList = cssList.map(item => {
+        return {
+          ...item,
+          value: isBackgroundImageEnabled && style.value ? `url(${site.mediaUrl}/${style.value})` : 'none'
+        };
+      });
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundAttachment') {
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-attachment',
+          value: style.value === 'fill' ? 'fixed' : style.value
+        }
+      );
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-size',
+          value: style.value === 'fill' ? 'cover' : 'auto'
+        }
+      );
+    }
+
+    if ((style.group === 'pageLayout' && ['contentWidth', 'paddingLeft'].indexOf(style.slug) > -1) || (style.group === 'sideBar' && style.slug === 'width')) {
+      const contentWidth: number = parseInt(this.getSettingValue(templateSettings, 'pageLayout', 'contentWidth') as string, 10);
+      const paddingLeft: number = parseInt(this.getSettingValue(templateSettings, 'pageLayout', 'paddingLeft') as string, 10);
+      const sideBarWidth: number = parseInt(this.getSettingValue(templateSettings, 'sideBar', 'width') as string, 10);
+
+      cssList.push(
+        {
+          selector: '#allContainer.xCentered',
+          property: 'max-width',
+          value: `${contentWidth + paddingLeft + sideBarWidth}px`
+        }
+      );
+
+      cssList.push(
+        {
+          selector: '#sideColumn.xCentered',
+          property: 'margin-left',
+          value: `-${(contentWidth + paddingLeft + sideBarWidth) / 2}px`
+        }
+      );
+
+      cssList.push(
+        {
+          selector: '#mainColumn.xCentered',
+          property: 'margin-left',
+          value: `-${(contentWidth + paddingLeft + sideBarWidth) / 2 - sideBarWidth}px`
+        }
+      );
+    }
+
+    if (style.group === 'firstPage' && style.slug === 'imageHaveShadows') {
+      const imageHaveShadows = style.value === 'yes';
+      const value = imageHaveShadows ? '5px 5px 2px #ccc' : 'none';
+      cssList.push(
+        {
+          selector: '.firstPagePic img',
+          property: 'box-shadow',
+          value: value
+        }
+      );
+      cssList.push(
+        {
+          selector: '.firstPagePic video',
+          property: 'box-shadow',
+          value: value
+        }
+      );
+    }
+
+    if ((style.group === 'sideBar' && ['backgroundColor', 'transparent'].indexOf(style.slug) > -1)) {
+      const isTransparent = this.getSettingValue(templateSettings, 'sideBar', 'transparent') === 'yes';
+      const backgroundColor = this.getSettingValue(templateSettings, 'sideBar', 'backgroundColor');
+      cssList.push(
+        {
+          selector: '#sideColumn',
+          property: 'background-color',
+          value: isTransparent ? 'transparent' : backgroundColor
+        }
+      );
+    }
+
+    return cssList;
+  }
+
+  getSettingValue(templateSettings: SettingsGroupModel[], group: string, slug: string) {
+    return templateSettings.find(g => g.slug === group).settings.find(s => s.slug === slug).value;
+  }
+}

--- a/editor/src/app/preview/messy-template-style.service.ts
+++ b/editor/src/app/preview/messy-template-style.service.ts
@@ -1,0 +1,149 @@
+import { Injectable } from '@angular/core';
+import { SettingsGroupModel } from '../shared/interfaces';
+import { SiteStateModel } from '../sites/sites-state/site-state.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MessyTemplateStyleService {
+
+  constructor() { }
+
+  getCSSList(style, cssList, site: SiteStateModel, template: string, templateSettings: SettingsGroupModel[]) {
+    if (style.group === 'background' && style.slug === 'backgroundImageEnabled') {
+      const isBackgroundImageEnabled = style.value === 'yes';
+      const backgroundImage = this.getSettingValue(templateSettings, 'background', 'backgroundImage');
+
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-image',
+          value: isBackgroundImageEnabled && backgroundImage ? `url(${site.mediaUrl}/${backgroundImage})` : 'none'
+        }
+      );
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundImage') {
+      const isBackgroundImageEnabled = this.getSettingValue(templateSettings, 'background', 'backgroundImageEnabled') === 'yes';
+      cssList = cssList.map(item => {
+        return {
+          ...item,
+          value: isBackgroundImageEnabled && style.value ? `url(${site.mediaUrl}/${style.value})` : 'none'
+        };
+      });
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundAttachment') {
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-attachment',
+          value: style.value === 'fill' ? 'fixed' : style.value
+        }
+      );
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-size',
+          value: style.value === 'fill' ? 'cover' : 'auto'
+        }
+      );
+    }
+
+    if (style.group === 'grid' && style.slug === 'contentWidth') {
+      cssList.push(
+        {
+          selector: '#xGridView',
+          property: 'left',
+          value: `${(100 - parseInt(style.value, 10)) / 2}%`
+        }
+      );
+      cssList.push(
+        {
+          selector: '#xGridView',
+          property: 'right',
+          value: `${(100 - parseInt(style.value, 10)) / 2}%`
+        }
+      );
+      cssList.push(
+        {
+          selector: '#xGridView',
+          property: 'width',
+          value: style.value
+        }
+      );
+    }
+
+    if (style.group === 'pageLayout' && style.slug === 'bgButtonType') {
+      const templatePath = `/_templates/${template}`;
+      cssList = [...cssList, ...[
+        {
+          selector: '#xBackground #xBackgroundLoader',
+          property: 'background',
+          value: `url(${templatePath}/layout/loader_${style.value}.gif) no-repeat`
+        },
+        {
+          selector: '#xBackground #xBackgroundRight',
+          property: 'cursor',
+          value: `url(${templatePath}/layout/arrow_right_${style.value}.gif), pointer`
+        },
+        {
+          selector: '#xBackground #xBackgroundLeft',
+          property: 'cursor',
+          value: `url(${templatePath}/layout/arrow_left_${style.value}.gif), pointer`
+        },
+        {
+          selector: '#xBackground #xBackgroundRightCounter .counterContent',
+          property: 'cursor',
+          value: `url(${templatePath}/layout/arrow_right_${style.value}.gif), pointer`
+        },
+        {
+          selector: '#xBackground #xBackgroundLeftCounter .counterContent',
+          property: 'cursor',
+          value: `url(${templatePath}/layout/arrow_left_${style.value}.gif), pointer`
+        },
+        {
+          selector: '#xBackgroundNext a',
+          property: 'background',
+          value: `url(${templatePath}/layout/bg_nav_buttons_${style.value}.png)`
+        },
+        {
+          selector: '#xBackgroundPrevious a',
+          property: 'background',
+          value: `url(${templatePath}/layout/bg_nav_buttons_${style.value}.png)`
+        },
+        {
+          selector: '#xGridViewTriggerContainer a',
+          property: 'background',
+          value: `url(${templatePath}/layout/bg_nav_buttons_${style.value}.png)`
+        }
+      ]];
+    }
+
+    if (style.group === 'pageLayout' && style.slug === 'centeringGuidesColor') {
+      cssList.push(
+        {
+          selector: '.xCenteringGuide',
+          property: 'background-color',
+          value: style.value === 'dark' ? 'rgba(0,0,0,0.5)' : 'rgba(255,255,255,0.5)'
+        }
+      );
+    }
+
+    if (style.group === 'entryLayout' && style.slug === 'contentWidth') {
+      cssList.push(
+        {
+          selector: '#xBackground .visual-caption',
+          property: 'margin-left',
+          value: `-${parseInt(style.value, 10) / 2}px`
+        }
+      );
+    }
+
+    return cssList;
+  }
+
+  getSettingValue(templateSettings: SettingsGroupModel[], group: string, slug: string) {
+    return templateSettings.find(g => g.slug === group).settings.find(s => s.slug === slug).value;
+  }
+}

--- a/editor/src/app/preview/preview.component.ts
+++ b/editor/src/app/preview/preview.component.ts
@@ -197,9 +197,7 @@ export class PreviewComponent implements OnInit {
 
         this.styleChangesSubscription = this.store.select(SiteTemplateSettingsState.getCurrentSiteTemplateSettings).pipe(
           pairwise()
-        ).subscribe((settingsPair: SettingsGroupModel[][]) => {
-          const prevSettings = settingsPair[0];
-          const curSettings = settingsPair[1];
+        ).subscribe(([prevSettings, curSettings]: SettingsGroupModel[][]) => {
 
           const stylesToChange = curSettings.reduce((stylesToChange: any, settingsGroup) => {
             settingsGroup.settings.forEach(setting => {

--- a/editor/src/app/preview/preview.component.ts
+++ b/editor/src/app/preview/preview.component.ts
@@ -239,6 +239,7 @@ export class PreviewComponent implements OnInit {
           take(1)
         ).subscribe(() => {
           this.styleChangesSubscription.unsubscribe();
+          iframe.contentWindow.location.reload();
         });
       },
       error: (error) => {

--- a/editor/src/app/preview/preview.component.ts
+++ b/editor/src/app/preview/preview.component.ts
@@ -193,7 +193,7 @@ export class PreviewComponent implements OnInit {
 
         const styleElement = iframe.contentDocument.createElement('style');
         iframe.contentDocument.head.appendChild(styleElement);
-        this.styleService.initializeStyleSheet(styleElement.sheet as CSSStyleSheet);
+        this.styleService.initializeStyleSheet(iframe.contentWindow, styleElement.sheet as CSSStyleSheet);
 
         this.styleChangesSubscription = combineLatest(
           this.store.select(SitesState.getCurrentSite),

--- a/editor/src/app/preview/preview.component.ts
+++ b/editor/src/app/preview/preview.component.ts
@@ -2,15 +2,19 @@ import { Component, OnInit, NgZone } from '@angular/core';
 import { Router } from '@angular/router';
 import { SafeUrl, DomSanitizer } from '@angular/platform-browser';
 import { HttpClient } from '@angular/common/http';
-import { Observable, combineLatest } from 'rxjs';
-import { take, filter, debounceTime } from 'rxjs/operators';
+import { Observable, combineLatest, Subscription } from 'rxjs';
+import { take, filter, debounceTime, pairwise } from 'rxjs/operators';
 import { Store } from '@ngxs/store';
 
 import { AppState } from '../app-state/app.state';
 import { UserState } from '../user/user.state';
+import { SiteTemplateSettingsState } from '../sites/template-settings/site-template-settings.state';
 import { PreviewService } from './preview.service';
 import { AppShowLoading, UpdateAppStateAction } from '../app-state/app.actions';
 import { UserLogoutAction } from '../user/user.actions';
+import { StyleService } from './style.service';
+import { SettingsGroupModel } from '../shared/interfaces';
+import { SiteSettingsState } from '../sites/settings/site-settings.state';
 
 interface IframeLocation {
   site: null|string;
@@ -47,12 +51,14 @@ export class PreviewComponent implements OnInit {
     site: undefined,
     section: undefined
   };
+  styleChangesSubscription: Subscription;
 
   constructor(
     private router: Router,
     private store: Store,
     private ngZone: NgZone,
     private service: PreviewService,
+    private styleService: StyleService,
     private sanitizer: DomSanitizer,
     private http: HttpClient) {
   }
@@ -184,6 +190,52 @@ export class PreviewComponent implements OnInit {
         iframe.contentWindow.onbeforeunload = () => {
           this.service.disconnectIframeView(iframe);
         };
+
+        const styleElement = iframe.contentDocument.createElement('style');
+        iframe.contentDocument.head.appendChild(styleElement);
+        this.styleService.initializeStyleSheet(styleElement.sheet as CSSStyleSheet);
+
+        this.styleChangesSubscription = this.store.select(SiteTemplateSettingsState.getCurrentSiteTemplateSettings).pipe(
+          pairwise()
+        ).subscribe((settingsPair: SettingsGroupModel[][]) => {
+          const prevSettings = settingsPair[0];
+          const curSettings = settingsPair[1];
+
+          const stylesToChange = curSettings.reduce((stylesToChange: any, settingsGroup) => {
+            settingsGroup.settings.forEach(setting => {
+              const prevSettingGroup = prevSettings.find(prevSettingsGroup => prevSettingsGroup.slug == settingsGroup.slug);
+              if (!prevSettingGroup) {
+                return stylesToChange;
+              }
+              const prevSetting = prevSettingGroup.settings.find(prevSetting => prevSetting.slug == setting.slug);
+              if (!prevSetting) {
+                return stylesToChange;
+              }
+              if (setting.value !== prevSetting.value) {
+                stylesToChange.push({
+                  group: settingsGroup.slug,
+                  slug: setting.slug,
+                  value: setting.value
+                });
+              }
+            });
+
+            return stylesToChange;
+          }, []);
+
+          stylesToChange.forEach(styleToChange => {
+            this.styleService.updateStyle(styleToChange);
+          });
+        });
+
+        // Unsubscribe from style changes if template has changed
+        // After iframe reload styles updates again
+        this.store.select(SiteSettingsState.getCurrentSiteTemplate).pipe(
+          pairwise(),
+          take(1)
+        ).subscribe(() => {
+          this.styleChangesSubscription.unsubscribe();
+        });
       },
       error: (error) => {
         console.error(error);

--- a/editor/src/app/preview/preview.service.ts
+++ b/editor/src/app/preview/preview.service.ts
@@ -48,6 +48,7 @@ export class PreviewService {
   private templateSettingsRequireReload = {
     pageLayout: [
       'centered',
+      'centeredWidth',
       'responsive',
       'mashUpColumns',
       'autoResponsive',

--- a/editor/src/app/preview/preview.service.ts
+++ b/editor/src/app/preview/preview.service.ts
@@ -45,6 +45,37 @@ import { UpdateShopSettingsAction } from '../shop/settings/shop-settings.actions
 })
 export class PreviewService {
   private iframeReloadSubscription: Subscription;
+  private templateSettingsRequireReload = {
+    pageLayout: [
+      'centered',
+      'responsive',
+      'mashUpColumns',
+      'autoResponsive',
+      'centeredContents'
+    ],
+    pageHeading: [
+      'image'
+    ],
+    css: [
+      'customCSS'
+    ],
+    entryLayout: [
+      'galleryPosition'
+    ],
+    firstPage: [
+      'hoverWiggle'
+    ],
+    sideBar: [
+      'image'
+    ],
+    heading: [
+      'image'
+    ],
+    tagsMenu: [
+      'alwaysOpen',
+      'hidden'
+    ]
+  };
 
   constructor(
     private appService: AppStateService,
@@ -420,7 +451,12 @@ export class PreviewService {
         }, [false, false]),
         filter(([prev, cur]) => prev !== cur && !cur)
       )),
-      filter(actionsPassed => actionsPassed.length > 0),
+      filter(actionsPassed => {
+        return actionsPassed.length > 0 && !actionsPassed.every(action => {
+          const slug = Object.keys(action.payload)[0];
+          return action instanceof UpdateSiteTemplateSettingsAction && !(this.templateSettingsRequireReload[action.settingGroup] && this.templateSettingsRequireReload[action.settingGroup].indexOf(slug) > -1);
+        });
+      })
     ).subscribe(() => {
       iframe.contentWindow.location.reload();
     });

--- a/editor/src/app/preview/preview.service.ts
+++ b/editor/src/app/preview/preview.service.ts
@@ -70,7 +70,11 @@ export class PreviewService {
       'image'
     ],
     heading: [
-      'image'
+      'image',
+      'position'
+    ],
+    menu: [
+      'position'
     ],
     tagsMenu: [
       'alwaysOpen',

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StyleService {
+  styleSheet: CSSStyleSheet;
+
+  initializeStyleSheet(styleSheet: CSSStyleSheet) {
+    this.styleSheet = styleSheet;
+  }
+
+  updateStyle(styleToChange) {
+  }
+}

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -6,6 +6,7 @@ import { SettingsGroupModel } from '../shared/interfaces';
 import { SiteTemplatesState } from '../sites/template-settings/site-templates.state';
 import { WhiteTemplateStyleService } from './white-template-style.service';
 import { DefaultTemplateStyleService } from './default-template-style.service';
+import { MashupTemplateStyleService } from './mashup-template-style.service';
 import { SiteStateModel } from '../sites/sites-state/site-state.model';
 
 @Injectable({
@@ -18,7 +19,8 @@ export class StyleService {
   constructor(
     private store: Store,
     private whiteTemplateStyleService: WhiteTemplateStyleService,
-    private defaultTemplateStyleService: DefaultTemplateStyleService) {
+    private defaultTemplateStyleService: DefaultTemplateStyleService,
+    private mashupTemplateStyleService: MashupTemplateStyleService) {
   }
 
   initializeStyleSheet(styleSheet: CSSStyleSheet) {
@@ -52,6 +54,10 @@ export class StyleService {
 
       case 'default':
         cssList = this.defaultTemplateStyleService.getCSSList(style, cssList, site, templateSettings);
+        break;
+
+      case 'mashup':
+        cssList = this.mashupTemplateStyleService.getCSSList(style, cssList, site, templateSettings);
         break;
 
       default:

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -39,7 +39,8 @@ export class StyleService {
 
     setting.css.forEach(rule => {
       const cssRule = this.findOrCreateRule(rule.selector, rule.breakpoint);
-      cssRule.style.setProperty(rule.property, style.value || setting.default);
+      const value = style.value || setting.default
+      cssRule.style.setProperty(rule.property, value, rule.important ? 'important' : null);
     });
   }
 

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -44,9 +44,23 @@ export class StyleService {
   }
 
   findOrCreateRule(selector: string, breakpoint: string): CSSStyleRule {
-    // @todo implement breakpoint usage
+    let cssMediaRule: CSSMediaRule;
+    let cssRulesList = this.styleSheet.cssRules;
 
-    const cssRule = Array.prototype.find.call(this.styleSheet.cssRules, (rule: CSSStyleRule) => {
+    if (breakpoint) {
+      cssMediaRule = Array.prototype.find.call(this.styleSheet.cssRules, (rule: CSSMediaRule) => {
+        return rule.conditionText === breakpoint;
+      });
+
+      if (!cssMediaRule) {
+        this.styleSheet.insertRule(`@media ${breakpoint} {}`, this.styleSheet.cssRules.length);
+        cssMediaRule = this.styleSheet.cssRules[this.styleSheet.cssRules.length - 1] as CSSMediaRule;
+      }
+
+      cssRulesList = cssMediaRule.cssRules;
+    }
+
+    const cssRule = Array.prototype.find.call(cssRulesList, (rule: CSSStyleRule) => {
       return rule.selectorText === selector;
     });
 
@@ -54,9 +68,12 @@ export class StyleService {
       return cssRule;
     }
 
-    const insertIndex = this.styleSheet.cssRules.length;
-    this.styleSheet.insertRule(`${selector} {}`, insertIndex);
-
-    return this.styleSheet.cssRules[insertIndex] as CSSStyleRule;
+    if (breakpoint) {
+      cssMediaRule.insertRule(`${selector} {}`, 0);
+      return cssMediaRule.cssRules[0] as CSSStyleRule;
+    } else {
+      this.styleSheet.insertRule(`${selector} {}`);
+      return this.styleSheet.cssRules[0] as CSSStyleRule;
+    }
   }
 }

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -39,11 +39,8 @@ export class StyleService {
 
     setting.css.forEach(rule => {
       const cssRule = this.findOrCreateRule(rule.selector, rule.breakpoint);
-      cssRule.style.setProperty(rule.property, style.value);
+      cssRule.style.setProperty(rule.property, style.value || setting.default);
     });
-
-
-    console.log(this.styleSheet);
   }
 
   findOrCreateRule(selector: string, breakpoint: string): CSSStyleRule {

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -5,6 +5,7 @@ import { TemplateSiteModel } from '../sites/template-settings/site-templates.int
 import { SettingsGroupModel } from '../shared/interfaces';
 import { SiteTemplatesState } from '../sites/template-settings/site-templates.state';
 import { WhiteTemplateStyleService } from './white-template-style.service';
+import { DefaultTemplateStyleService } from './default-template-style.service';
 import { SiteStateModel } from '../sites/sites-state/site-state.model';
 
 @Injectable({
@@ -16,7 +17,8 @@ export class StyleService {
 
   constructor(
     private store: Store,
-    private whiteTemplateStyleService: WhiteTemplateStyleService) {
+    private whiteTemplateStyleService: WhiteTemplateStyleService,
+    private defaultTemplateStyleService: DefaultTemplateStyleService) {
   }
 
   initializeStyleSheet(styleSheet: CSSStyleSheet) {
@@ -46,6 +48,10 @@ export class StyleService {
     switch (templateName) {
       case 'white':
         cssList = this.whiteTemplateStyleService.getCSSList(style, cssList, site, templateSettings);
+        break;
+
+      case 'default':
+        cssList = this.defaultTemplateStyleService.getCSSList(style, cssList, site, templateSettings);
         break;
 
       default:

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -1,15 +1,65 @@
 import { Injectable } from '@angular/core';
+import { Store } from '@ngxs/store';
+import { take } from 'rxjs/operators';
+import { TemplateSiteModel } from '../sites/template-settings/site-templates.interface';
+import { SiteTemplatesState } from '../sites/template-settings/site-templates.state';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StyleService {
   styleSheet: CSSStyleSheet;
+  templateConfig: TemplateSiteModel['templateConf'];
+
+  constructor(
+    private store: Store) {
+  }
 
   initializeStyleSheet(styleSheet: CSSStyleSheet) {
     this.styleSheet = styleSheet;
+    this.store.select(SiteTemplatesState.getCurrentTemplateConfig).pipe(take(1)).subscribe((templateConfig) => {
+      this.templateConfig = templateConfig;
+    });
   }
 
-  updateStyle(styleToChange) {
+  updateStyle(style) {
+    const settingGroup = this.templateConfig[style.group];
+    if (!settingGroup) {
+      return;
+    }
+
+    const setting = settingGroup[style.slug];
+    if (!setting) {
+      return;
+    }
+
+    if (!setting.css) {
+      return;
+    }
+
+    setting.css.forEach(rule => {
+      const cssRule = this.findOrCreateRule(rule.selector, rule.breakpoint);
+      cssRule.style.setProperty(rule.property, style.value);
+    });
+
+
+    console.log(this.styleSheet);
+  }
+
+  findOrCreateRule(selector: string, breakpoint: string): CSSStyleRule {
+    // @todo implement breakpoint usage
+
+    const cssRule = Array.prototype.find.call(this.styleSheet.cssRules, (rule: CSSStyleRule) => {
+      return rule.selectorText === selector;
+    });
+
+    if (cssRule) {
+      return cssRule;
+    }
+
+    const insertIndex = this.styleSheet.cssRules.length;
+    this.styleSheet.insertRule(`${selector} {}`, insertIndex);
+
+    return this.styleSheet.cssRules[insertIndex] as CSSStyleRule;
   }
 }

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -39,7 +39,10 @@ export class StyleService {
 
     setting.css.forEach(rule => {
       const cssRule = this.findOrCreateRule(rule.selector, rule.breakpoint);
-      const value = style.value || setting.default
+      let value = style.value || setting.default
+      if (rule.template) {
+        value = eval(rule.template);
+      }
       cssRule.style.setProperty(rule.property, value, rule.important ? 'important' : null);
     });
   }

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -69,11 +69,11 @@ export class StyleService {
     }
 
     if (breakpoint) {
-      cssMediaRule.insertRule(`${selector} {}`, 0);
-      return cssMediaRule.cssRules[0] as CSSStyleRule;
+      cssMediaRule.insertRule(`${selector} {}`, cssMediaRule.cssRules.length);
+      return cssMediaRule.cssRules[cssMediaRule.cssRules.length - 1] as CSSStyleRule;
     } else {
-      this.styleSheet.insertRule(`${selector} {}`);
-      return this.styleSheet.cssRules[0] as CSSStyleRule;
+      this.styleSheet.insertRule(`${selector} {}`, this.styleSheet.cssRules.length);
+      return this.styleSheet.cssRules[this.styleSheet.cssRules.length - 1] as CSSStyleRule;
     }
   }
 }

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -7,6 +7,7 @@ import { SiteTemplatesState } from '../sites/template-settings/site-templates.st
 import { WhiteTemplateStyleService } from './white-template-style.service';
 import { DefaultTemplateStyleService } from './default-template-style.service';
 import { MashupTemplateStyleService } from './mashup-template-style.service';
+import { MessyTemplateStyleService } from './messy-template-style.service';
 import { SiteStateModel } from '../sites/sites-state/site-state.model';
 
 @Injectable({
@@ -20,7 +21,8 @@ export class StyleService {
     private store: Store,
     private whiteTemplateStyleService: WhiteTemplateStyleService,
     private defaultTemplateStyleService: DefaultTemplateStyleService,
-    private mashupTemplateStyleService: MashupTemplateStyleService) {
+    private mashupTemplateStyleService: MashupTemplateStyleService,
+    private messyTemplateStyleService: MessyTemplateStyleService) {
   }
 
   initializeStyleSheet(styleSheet: CSSStyleSheet) {
@@ -60,7 +62,9 @@ export class StyleService {
         cssList = this.mashupTemplateStyleService.getCSSList(style, cssList, site, templateSettings);
         break;
 
+      // Messy
       default:
+        cssList = this.messyTemplateStyleService.getCSSList(style, cssList, site, template, templateSettings);
         break;
     }
 

--- a/editor/src/app/preview/style.service.ts
+++ b/editor/src/app/preview/style.service.ts
@@ -41,7 +41,7 @@ export class StyleService {
       style.value = setting.default;
     }
 
-    let cssList = setting.css || [];
+    let cssList = setting.css ? [...setting.css] : [];
     const templateName = template.split('-')[0];
     switch (templateName) {
       case 'white':

--- a/editor/src/app/preview/white-template-style.service.ts
+++ b/editor/src/app/preview/white-template-style.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@angular/core';
+import { SettingsGroupModel } from '../shared/interfaces';
+import { SiteStateModel } from '../sites/sites-state/site-state.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WhiteTemplateStyleService {
+
+  constructor() { }
+
+  getCSSList(style, cssList, site: SiteStateModel, templateSettings: SettingsGroupModel[]) {
+    if (style.group === 'background' && style.slug === 'backgroundImageEnabled') {
+      const isBackgroundImageEnabled = style.value === 'yes';
+      const backgroundImage = this.getSettingValue(templateSettings, 'background', 'backgroundImage');
+
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-image',
+          value: isBackgroundImageEnabled && backgroundImage ? `url(${site.mediaUrl}/${backgroundImage})` : 'none'
+        }
+      );
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundImage') {
+      const isBackgroundImageEnabled = this.getSettingValue(templateSettings, 'background', 'backgroundImageEnabled') === 'yes';
+      cssList = cssList.map(item => {
+        return {
+          ...item,
+          value: isBackgroundImageEnabled && style.value ? `url(${site.mediaUrl}/${style.value})` : 'none'
+        };
+      });
+    }
+
+    if (style.group === 'background' && style.slug === 'backgroundAttachment') {
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-attachment',
+          value: style.value === 'fill' ? 'fixed' : style.value
+        }
+      );
+      cssList.push(
+        {
+          selector: 'body',
+          property: 'background-size',
+          value: style.value === 'fill' ? 'cover' : 'auto'
+        }
+      );
+    }
+
+    return cssList;
+  }
+
+  getSettingValue(templateSettings: SettingsGroupModel[], group: string, slug: string) {
+    return templateSettings.find(g => g.slug === group).settings.find(s => s.slug === slug).value;
+  }
+}

--- a/editor/src/app/preview/white-template-style.service.ts
+++ b/editor/src/app/preview/white-template-style.service.ts
@@ -50,6 +50,36 @@ export class WhiteTemplateStyleService {
       );
     }
 
+    if (style.group === 'pageLayout' && ['contentWidth', 'paddingLeft', 'leftColumnWidth'].indexOf(style.slug) > -1) {
+      const contentWidth: number = parseInt(this.getSettingValue(templateSettings, 'pageLayout', 'contentWidth') as string, 10);
+      const leftColumnWidth: number = parseInt(this.getSettingValue(templateSettings, 'pageLayout', 'leftColumnWidth') as string, 10);
+      const paddingLeft: number = parseInt(this.getSettingValue(templateSettings, 'pageLayout', 'paddingLeft') as string, 10);
+
+      cssList.push(
+        {
+          selector: '#allContainer.xCentered',
+          property: 'max-width',
+          value: `${contentWidth + leftColumnWidth + paddingLeft}px`
+        }
+      );
+
+      cssList.push(
+        {
+          selector: '#sideColumn.xCentered',
+          property: 'margin-left',
+          value: `-${(contentWidth + leftColumnWidth + paddingLeft) / 2}px`
+        }
+      );
+
+      cssList.push(
+        {
+          selector: '#mainColumn.xCentered',
+          property: 'margin-left',
+          value: `-${(leftColumnWidth + contentWidth + paddingLeft) / 2 - leftColumnWidth}px`
+        }
+      );
+    }
+
     return cssList;
   }
 

--- a/editor/src/app/shared/interfaces.ts
+++ b/editor/src/app/shared/interfaces.ts
@@ -46,7 +46,8 @@ export interface SettingConfigModel {
     selector: string;
     property: string;
     breakpoint?: string;
-    important?: boolean
+    important?: boolean;
+    template?: string;
   }>;
   html_entities?: boolean;
   css_units?: boolean;

--- a/editor/src/app/shared/interfaces.ts
+++ b/editor/src/app/shared/interfaces.ts
@@ -46,6 +46,7 @@ export interface SettingConfigModel {
     selector: string;
     property: string;
     breakpoint?: string;
+    important?: boolean
   }>;
   html_entities?: boolean;
   css_units?: boolean;

--- a/editor/src/app/shared/interfaces.ts
+++ b/editor/src/app/shared/interfaces.ts
@@ -48,6 +48,7 @@ export interface SettingConfigModel {
     breakpoint?: string;
     important?: boolean;
     template?: string;
+    value?: string;
   }>;
   html_entities?: boolean;
   css_units?: boolean;

--- a/editor/src/app/shared/interfaces.ts
+++ b/editor/src/app/shared/interfaces.ts
@@ -42,6 +42,11 @@ export interface SettingConfigModel {
     title: string;
     value: string | number;
   }>;
+  css?: Array<{
+    selector: string;
+    property: string;
+    breakpoint?: string;
+  }>;
   html_entities?: boolean;
   css_units?: boolean;
   min_width?: number | string;

--- a/editor/src/app/sites/sites-state/site-state.model.ts
+++ b/editor/src/app/sites/sites-state/site-state.model.ts
@@ -2,6 +2,7 @@ export interface SiteStateModel {
   name: string;
   title: string;
   order: number;
+  mediaUrl: string;
   '@attributes': {
     published: 0 | 1;
   };

--- a/editor/src/app/sites/sites-state/sites.state.ts
+++ b/editor/src/app/sites/sites-state/sites.state.ts
@@ -1,9 +1,10 @@
 import { set } from 'lodash/fp';
 import { concat } from 'rxjs';
 import { take, switchMap, tap } from 'rxjs/operators';
-import { State, Action, StateContext, NgxsOnInit, ofActionSuccessful, Actions } from '@ngxs/store';
+import { State, Action, StateContext, NgxsOnInit, ofActionSuccessful, Actions, Selector } from '@ngxs/store';
 
 import { SiteStateModel } from './site-state.model';
+import { AppState } from '../../app-state/app.state';
 import { AppStateService } from '../../app-state/app-state.service';
 import {
   CreateSiteAction,
@@ -42,6 +43,11 @@ import { UserLoginAction } from '../../user/user.actions';
   defaults: []
 })
 export class SitesState implements NgxsOnInit {
+
+  @Selector([AppState.getSite])
+  static getCurrentSite(sites: SiteStateModel[], siteSlug: string) {
+    return sites.find(site => site.name === siteSlug);
+  }
 
   constructor(
     private appStateService: AppStateService,


### PR DESCRIPTION
Listen on style changes and pass them to style service for setting the style using CSSOM.
- [x] Listen on style changes and pass them to style service
- [x] Define CSS selectors for style settings
- [x] Apply style using CSSOM
- [x] Define selectors for all template settings 
- [x] Prepare css value before preview, add quotes for `content`, add `url(` for `background-image`
- [x] Solve computed values with dependencies from other style settings
- [x] Load and use Google fonts
- [x] Remove iframe reload actions related to style changes