### PR TITLE
Enhance image gallery preview in editor

### DIFF
--- a/_api_app/app/Sites/Sections/Entries/SectionEntriesController.php
+++ b/_api_app/app/Sites/Sections/Entries/SectionEntriesController.php
@@ -128,7 +128,7 @@ class SectionEntriesController extends Controller
             ], 400);
         }
 
-        $ret = $sectionEntriesDataService->galleryUpload($path, $file);
+        $ret = $sectionEntriesDataService->galleryUpload($site, $path, $file);
 
         return response()->json($ret);
     }

--- a/_api_app/app/Sites/Sections/Entries/SectionEntriesDataService.php
+++ b/_api_app/app/Sites/Sections/Entries/SectionEntriesDataService.php
@@ -939,7 +939,7 @@ class SectionEntriesDataService extends Storage
         return ['error_message' => 'Entry with ID "' . $entry_id . '" not found!'];
     }
 
-    public function galleryUpload($path, $file)
+    public function galleryUpload($site, $path, $file)
     {
         $mediaRootDir = $this->getOrCreateMediaDir();
         $entries = $this->get();
@@ -1015,7 +1015,7 @@ class SectionEntriesDataService extends Storage
 
             // Add new Image
         } else {
-            $entry['mediaCacheData']['file'][] = [
+            $item = [
                 '@attributes' => [
                     'type' => 'image',
                     'src' => $fileName,
@@ -1023,6 +1023,19 @@ class SectionEntriesDataService extends Storage
                     'height' => $height,
                 ],
             ];
+            $entry['mediaCacheData']['file'][] = $item;
+
+            $storageService = new Storage($site);
+            $siteSettingsDataService = new SiteSettingsDataService($site);
+            $siteSettings = $siteSettingsDataService->getState();
+
+            // create image variant for gallery size
+            ImageHelpers::getGalleryItem(
+                $item,
+                $entry,
+                $storageService,
+                $siteSettings
+            );
         }
 
         $entries[self::$ROOT_LIST_ELEMENT][$entry_order] = $entry;

--- a/editor/src/app/rerender/template-rerender.service.ts
+++ b/editor/src/app/rerender/template-rerender.service.ts
@@ -107,7 +107,8 @@ export class TemplateRerenderService {
           AddSiteSectionBackgroundFileAction,
           UpdateSectionBackgroundFileAction,
           UpdateSiteSectionByPathAction,
-          ResetToDefaultsSiteTemplateSettingsAction
+          ResetToDefaultsSiteTemplateSettingsAction,
+          UpdateSectionEntryAction
         ),
         filter((action) => {
           const reloadConditionFromSiteSettingsAction =
@@ -150,12 +151,17 @@ export class TemplateRerenderService {
           const reloadConditionFromSiteTemplateSettings =
             action instanceof ResetToDefaultsSiteTemplateSettingsAction;
 
+          const reloadConditionFromUpdateSectionEntryActions =
+            action instanceof UpdateSectionEntryAction &&
+            action.path.endsWith('mediaCacheData/@attributes/size');
+
           return (
             reloadConditionFromSiteSettingsAction ||
             reloadConditionFromSectionAction ||
             reloadConditionFromShopSettingsAction ||
             reloadConditionFromBackgroundGalleryActions ||
-            reloadConditionFromSiteTemplateSettings
+            reloadConditionFromSiteTemplateSettings ||
+            reloadConditionFromUpdateSectionEntryActions
           );
         })
       )


### PR DESCRIPTION
- [x] Generate gallery thumbnail image size according to gallery image size on upload. 
- [x] Reload site preview in editor if gallery size changes to ensure all images in gallery are regenerated in correct size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Gallery uploads now respect site-specific settings, generating appropriate image variants/thumbnails for entries.
  - The editor automatically refreshes when media cache size changes, ensuring up-to-date gallery displays.

- Bug Fixes
  - Newly uploaded images reliably appear in entry galleries without manual refresh.
  - Media cache updates are properly detected, reducing stale or mismatched gallery states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->