### PR TITLE
Remove useDefineForClassFields from tsconfig

### DIFF
--- a/editor/src/app/app.component.ts
+++ b/editor/src/app/app.component.ts
@@ -3,7 +3,7 @@ import { Router, NavigationEnd } from '@angular/router';
 
 import { Subscription, Observable } from 'rxjs';
 import { take, switchMap, mergeMap, filter, map, tap } from 'rxjs/operators';
-import { Store, Select, Actions, ofActionSuccessful } from '@ngxs/store';
+import { Store, Actions, ofActionSuccessful } from '@ngxs/store';
 
 import { AppHideOverlay, AppShowOverlay } from './app-state/app.actions';
 import { AppState } from './app-state/app.state';
@@ -141,23 +141,23 @@ import { AppStateService } from './app-state/app-state.service';
   standalone: false,
 })
 export class AppComponent implements OnInit, OnDestroy {
-  title = 'berta';
+  readonly title = 'berta';
   routeIsRoot = true;
   isSidebarFullscreen = false;
   isSidebarFullWidth = false;
-  sidebarFullscreenRoutes = ['/themes'];
-  sidebarFullWidthRoutes = ['/media', '/background-gallery'];
+  readonly sidebarFullscreenRoutes = ['/themes'];
+  readonly sidebarFullWidthRoutes = ['/media', '/background-gallery'];
 
-  @Select(UserState) user$: Observable<UserStateModel>;
-  @Select(AppState.getShowOverlay) showOverlay$;
-  @Select(AppState.getInputFocus) inputFocus$: Observable<boolean>;
-  @Select(UserState.isLoggedIn) isLoggedIn$;
-  @Select(AppState.isSetup) isSetup$: Observable<boolean>;
+  user$: Observable<UserStateModel>;
+  showOverlay$: Observable<boolean>;
+  inputFocus$: Observable<boolean>;
+  isLoggedIn$: Observable<boolean>;
+  isSetup$: Observable<boolean>;
 
   private loginSub: Subscription;
   private logoutSub: Subscription;
-  private currentRouteUrl: string;
-  private previousRouteUrl: string;
+  private currentRouteUrl: string = '';
+  private previousRouteUrl: string = '';
 
   constructor(
     private router: Router,
@@ -165,7 +165,13 @@ export class AppComponent implements OnInit, OnDestroy {
     private _ngZone: NgZone,
     private stateService: AppStateService,
     private actions$: Actions,
-  ) {}
+  ) {
+    this.user$ = this.store.select((state) => state.user);
+    this.showOverlay$ = this.store.select(AppState.getShowOverlay);
+    this.inputFocus$ = this.store.select(AppState.getInputFocus);
+    this.isLoggedIn$ = this.store.select(UserState.isLoggedIn);
+    this.isSetup$ = this.store.select(AppState.isSetup);
+  }
 
   ngOnInit() {
     this.currentRouteUrl = this.router.url;

--- a/editor/src/app/header/header.component.ts
+++ b/editor/src/app/header/header.component.ts
@@ -1,8 +1,6 @@
 import { Component } from '@angular/core';
+import { Store } from '@ngxs/store';
 import { Observable } from 'rxjs';
-
-import { Select } from '@ngxs/store';
-
 import { AppState } from '../app-state/app.state';
 import { UserState } from '../user/user.state';
 import { UserStateModel } from '../user/user.state.model';
@@ -121,8 +119,15 @@ import { UserStateModel } from '../user/user.state.model';
   standalone: false,
 })
 export class HeaderComponent {
-  @Select(UserState) user$: Observable<UserStateModel>;
-  @Select(UserState.isLoggedIn) isLoggedIn$: Observable<boolean>;
-  @Select(AppState.getShowLoading) isLoading$: Observable<boolean>;
-  @Select(AppState.isSetup) isSetup$: Observable<boolean>;
+  user$: Observable<UserStateModel>;
+  isLoggedIn$: Observable<boolean>;
+  isLoading$: Observable<boolean>;
+  isSetup$: Observable<boolean>;
+
+  constructor(private store: Store) {
+    this.user$ = this.store.select((state) => state.user);
+    this.isLoggedIn$ = this.store.select(UserState.isLoggedIn);
+    this.isLoading$ = this.store.select(AppState.getShowLoading);
+    this.isSetup$ = this.store.select(AppState.isSetup);
+  }
 }

--- a/editor/src/app/header/preview-toggle.component.ts
+++ b/editor/src/app/header/preview-toggle.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router, ActivationEnd } from '@angular/router';
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
-import { Store, Select } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 
 import { AppState } from '../app-state/app.state';
 
@@ -51,14 +51,15 @@ import { AppState } from '../app-state/app.state';
   standalone: false,
 })
 export class PreviewToggleComponent implements OnInit {
-  @Select(AppState.getLastRoute) lastRoute$: Observable<string>;
-
+  lastRoute$: Observable<string>;
   isPreviewActive = true;
 
   constructor(
     private store: Store,
     private router: Router,
-  ) {}
+  ) {
+    this.lastRoute$ = this.store.select(AppState.getLastRoute);
+  }
 
   ngOnInit() {
     this.router.events

--- a/editor/src/app/profile-dropdown/profile-dropdown.component.ts
+++ b/editor/src/app/profile-dropdown/profile-dropdown.component.ts
@@ -1,8 +1,7 @@
 import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 
-import { UserState } from '../user/user.state';
 import { UserStateModel } from '../user/user.state.model';
 import { UserLogoutAction } from '../user/user.actions';
 
@@ -112,9 +111,11 @@ import { UserLogoutAction } from '../user/user.actions';
   standalone: false,
 })
 export class ProfileDropdownComponent {
-  @Select(UserState) user$: Observable<UserStateModel>;
+  user$: Observable<UserStateModel>;
 
-  constructor(private store: Store) {}
+  constructor(private store: Store) {
+    this.user$ = this.store.select((state) => state.user);
+  }
 
   logOut() {
     this.store.dispatch(new UserLogoutAction());

--- a/editor/src/app/shop/orders/shop-orders.component.ts
+++ b/editor/src/app/shop/orders/shop-orders.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { Select } from '@ngxs/store';
+import { Store } from '@ngxs/store';
+import { Observable } from 'rxjs';
 
 import { stringToCurrency } from '../../shared/helpers';
 import { ShopSettingsState } from '../settings/shop-settings.state';
@@ -128,8 +129,13 @@ import { ShopOrdersState } from './shop-orders.state';
   standalone: false,
 })
 export class ShopOrdersComponent {
-  @Select(ShopOrdersState.getCurrentSiteOrders) orders$;
-  @Select(ShopSettingsState.getCurrentCurrency) currency$;
+  orders$: Observable<any[]>;
+  currency$: Observable<string>;
+
+  constructor(private store: Store) {
+    this.orders$ = this.store.select(ShopOrdersState.getCurrentSiteOrders);
+    this.currency$ = this.store.select(ShopSettingsState.getCurrentCurrency);
+  }
 
   stringToCurrency(price) {
     return stringToCurrency(price);

--- a/editor/src/app/shop/regional-costs/shop-regional-costs.component.ts
+++ b/editor/src/app/shop/regional-costs/shop-regional-costs.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, shareReplay } from 'rxjs/operators';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 
 import { PopupService } from '../../popup/popup.service';
 import { ShopSettingsState } from '../settings/shop-settings.state';
-import { ShopRegionalCostsState } from './shop-regional-costs.state';
+import {
+  ShopRegion,
+  ShopRegionalCostsState,
+} from './shop-regional-costs.state';
 import { UpdateInputFocus } from '../../app-state/app.actions';
 import {
   UpdateShopRegionAction,
@@ -159,7 +162,7 @@ import {
   standalone: false,
 })
 export class ShopRegionalCostsComponent implements OnInit {
-  @Select(ShopRegionalCostsState.getCurrentSiteRegionalCosts) regionalCosts$;
+  regionalCosts$: Observable<ShopRegion[]>;
   weightLabel$: Observable<string>;
   weightTitle$: Observable<string>;
   priceLabel$: Observable<string>;
@@ -178,7 +181,11 @@ export class ShopRegionalCostsComponent implements OnInit {
   constructor(
     private store: Store,
     private popupService: PopupService,
-  ) {}
+  ) {
+    this.regionalCosts$ = this.store.select(
+      ShopRegionalCostsState.getCurrentSiteRegionalCosts,
+    );
+  }
 
   ngOnInit() {
     this.weightLabel$ = this.store

--- a/editor/src/app/shop/regional-costs/shop-regional-costs.state.ts
+++ b/editor/src/app/shop/regional-costs/shop-regional-costs.state.ts
@@ -41,20 +41,20 @@ import { combineLatest, startWith } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SwapContentsSitesAction } from 'src/app/sites/sites-state/sites.actions';
 
-interface ShopRegion {
+export interface ShopRegion {
   id: number;
   name: string;
   vat: number;
   costs: ShopRegionalCost[];
 }
 
-interface ShopRegionalCost {
+export interface ShopRegionalCost {
   id: number;
   weight: number;
   price: number;
 }
 
-interface ShopRegionalCostsModel {
+export interface ShopRegionalCostsModel {
   [site: string]: ShopRegion[];
 }
 

--- a/editor/src/app/sites/media/entry-gallery-editor.component.ts
+++ b/editor/src/app/sites/media/entry-gallery-editor.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable, combineLatest } from 'rxjs';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import type { NgsgOrderChange } from 'ng-sortgrid';
 import { Animations } from '../../shared/animations';
 import {
@@ -428,15 +428,14 @@ import { SiteSettingsState } from '../settings/site-settings.state';
   standalone: false,
 })
 export class EntryGalleryEditorComponent implements OnInit {
-  @Select(SitesState.getCurrentSite)
-  currentSite$: Observable<SiteStateModel>;
+  private readonly currentSite$: Observable<SiteStateModel>;
   currentSite: SiteStateModel;
   currentSection: SiteSectionStateModel;
   currentEntry: SectionEntry;
   templateName: string;
   selectedFile: SectionEntryGalleryFile;
-  fileSettingsIsOpen = true;
-  gallerySettingsIsOpen = true;
+  fileSettingsIsOpen: boolean = true;
+  gallerySettingsIsOpen: boolean = true;
   uploadFilesErrors: string[] = [];
 
   constructor(
@@ -444,7 +443,9 @@ export class EntryGalleryEditorComponent implements OnInit {
     private route: ActivatedRoute,
     private store: Store,
     private popupService: PopupService,
-  ) {}
+  ) {
+    this.currentSite$ = this.store.select(SitesState.getCurrentSite);
+  }
 
   ngOnInit() {
     this.route.paramMap

--- a/editor/src/app/sites/media/entry-gallery-image-editor.component.ts
+++ b/editor/src/app/sites/media/entry-gallery-image-editor.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { Observable } from 'rxjs';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import { Animations } from '../../shared/animations';
 import {
   SectionEntry,
@@ -124,7 +124,7 @@ import { SitesSharedModule } from '../shared/sites-shared.module';
   animations: [Animations.slideToggle],
 })
 export class EntryGalleryImageEditorComponent implements OnInit {
-  @Select(SitesState.getCurrentSite) currentSite$: Observable<SiteStateModel>;
+  currentSite$: Observable<SiteStateModel>;
   site: SiteStateModel;
   sectionName: SiteSectionStateModel['name'];
   entryId: SectionEntry['id'];
@@ -144,6 +144,7 @@ export class EntryGalleryImageEditorComponent implements OnInit {
     private route: ActivatedRoute,
     private http: HttpClient,
   ) {
+    this.currentSite$ = this.store.select(SitesState.getCurrentSite);
     this.position = { x1: 0, y1: 0, x2: 0, y2: 0 };
   }
 

--- a/editor/src/app/sites/media/site-media.component.ts
+++ b/editor/src/app/sites/media/site-media.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import { Observable, Subject } from 'rxjs';
 import { combineLatest } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
@@ -32,7 +32,7 @@ import { SectionEntry } from '../sections/entries/entries-state/section-entries-
             </a>
           </h3>
         </div>
-        @for (section of sectionsList; track section) {
+        @for (section of sectionsList; track section.section.name) {
           <div class="setting-group">
             <h3>
               <a
@@ -96,7 +96,7 @@ import { SectionEntry } from '../sections/entries/entries-state/section-entries-
   standalone: false,
 })
 export class SiteMediaComponent implements OnInit, OnDestroy {
-  @Select(SitesState.getCurrentSite) currentSite$: Observable<SiteStateModel>;
+  readonly currentSite$: Observable<SiteStateModel>;
 
   sectionsList: {
     section: SiteSectionStateModel;
@@ -120,7 +120,9 @@ export class SiteMediaComponent implements OnInit, OnDestroy {
   constructor(
     private store: Store,
     private route: ActivatedRoute,
-  ) {}
+  ) {
+    this.currentSite$ = this.store.select(SitesState.getCurrentSite);
+  }
 
   ngOnInit() {
     combineLatest([

--- a/editor/src/app/sites/sections/background-gallery-editor.component.ts
+++ b/editor/src/app/sites/sections/background-gallery-editor.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import { Observable, combineLatest } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 import { SitesState } from '../sites-state/sites.state';
@@ -326,21 +326,22 @@ import type { NgsgOrderChange } from 'ng-sortgrid';
   standalone: false,
 })
 export class BackgroundGalleryEditorComponent implements OnInit {
-  @Select(SitesState.getCurrentSite)
-  currentSite$: Observable<SiteStateModel>;
+  private readonly currentSite$: Observable<SiteStateModel>;
   currentSite: SiteStateModel;
   currentSection: SiteSectionStateModel;
   selectedFile: SiteSectionBackgroundFile;
   uploadFilesErrors: string[] = [];
-  fileSettingsIsOpen = true;
-  gallerySettingsIsOpen = true;
+  fileSettingsIsOpen: boolean = true;
+  gallerySettingsIsOpen: boolean = true;
 
   constructor(
     private router: Router,
     private route: ActivatedRoute,
     private store: Store,
     private popupService: PopupService,
-  ) {}
+  ) {
+    this.currentSite$ = this.store.select(SitesState.getCurrentSite);
+  }
 
   ngOnInit() {
     this.route.paramMap

--- a/editor/src/app/sites/settings/site-settings.component.ts
+++ b/editor/src/app/sites/settings/site-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { SafeHtml, DomSanitizer } from '@angular/platform-browser';
-import { Store, Select } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import { Observable, combineLatest } from 'rxjs';
 import { map, filter, scan, take } from 'rxjs/operators';
 import { splitCamel, uCFirst, getIconFromUrl } from '../../shared/helpers';
@@ -169,14 +169,17 @@ export class SiteSettingsComponent implements OnInit {
   settingUpdate: { [k: string]: boolean } = {};
   settingError: { [k: string]: string } = {};
 
-  @Select((state) => state.user) user$: Observable<UserStateModel>;
-  @Select((state) => state.app) appState$: Observable<AppStateModel>;
+  readonly user$: Observable<UserStateModel>;
+  readonly appState$: Observable<AppStateModel>;
 
   constructor(
     private store: Store,
     private route: ActivatedRoute,
     private sanitizer: DomSanitizer,
-  ) {}
+  ) {
+    this.user$ = this.store.select((state) => state.user);
+    this.appState$ = this.store.select((state) => state.app);
+  }
 
   ngOnInit() {
     this.settings$ = combineLatest([

--- a/editor/src/app/user/auth-guard.service.ts
+++ b/editor/src/app/user/auth-guard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Router, ActivatedRouteSnapshot, CanActivate } from '@angular/router';
-import { Select, Store } from '@ngxs/store';
+import { Store } from '@ngxs/store';
 import { UserState } from './user.state';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -10,12 +10,14 @@ import { SetUserNextUrlAction } from './user.actions';
   providedIn: 'root',
 })
 export class AuthGuardService implements CanActivate {
-  @Select(UserState.isLoggedIn) isLoggedIn$: Observable<boolean>;
+  private readonly isLoggedIn$: Observable<boolean>;
 
   constructor(
     private store: Store,
     private router: Router,
-  ) {}
+  ) {
+    this.isLoggedIn$ = this.store.select(UserState.isLoggedIn);
+  }
 
   canActivate(route: ActivatedRouteSnapshot) {
     return this.isLoggedIn$.pipe(

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -12,7 +12,6 @@
     "isolatedModules": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "useDefineForClassFields": false,
     "target": "ES2022",
     "module": "preserve"
   },


### PR DESCRIPTION
- Remove useDefineForClassFields from tsconfig, use the default `true` value.
- Remove deprecated `@Select` decorator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored state management architecture for improved maintainability and consistency across components.
  * Made configuration properties readonly to enhance immutability guarantees.
  * Exported internal type definitions to improve type safety and reusability.
  * Added explicit type annotations for enhanced code clarity and reliability.
  * Simplified TypeScript configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->