### PR TITLE
Fix entry width rendering in editor

### DIFF
--- a/editor/src/app/sites/sections/entries/section-entry-render.service.ts
+++ b/editor/src/app/sites/sections/entries/section-entry-render.service.ts
@@ -90,7 +90,7 @@ export class SectionEntryRenderService {
     styles.push(`left:${left}px;top:${top}px`);
 
     if (entry.content && entry.content.width) {
-      styles.push(`width:${entry.content.width}px`);
+      styles.push(`width:${entry.content.width}`);
     } else if (
       currentSectionType === 'shop' &&
       shopSettings.group_price_item &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected entry width styling to preserve provided units.
  * Retained the default pixel-based width when no custom width is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->