### PR TITLE
Fix content shift in editor if gallery is empty

### DIFF
--- a/engine/css/editor.css.php
+++ b/engine/css/editor.css.php
@@ -459,8 +459,16 @@ body .tox-tinymce-aux {
 
 .xGalleryContainer  {
     clear: left;
-    min-height: 20px;
 }
+    .xGalleryContainer:not(.xGalleryHasImages) {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height .15s ease-out;
+    }
+    .xEntry:hover .xGalleryContainer:not(.xGalleryHasImages),
+    .xEntry:focus-within .xGalleryContainer:not(.xGalleryHasImages) {
+        max-height: 24px;
+    }
     .xGalleryContainer .entryGallery {
         position: relative;
     }


### PR DESCRIPTION
Fix content shift in editor if gallery is empty: shows placeholder on entry hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Empty gallery areas now collapse automatically, reducing unnecessary whitespace.
  * Gallery areas smoothly expand when the related entry is hovered or focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->